### PR TITLE
provisioning: fix build on arm64 by adding stubs

### DIFF
--- a/provisioning.go
+++ b/provisioning.go
@@ -1,4 +1,6 @@
-package fdeutils
+// +build !arm64
+
+package fdeutil
 
 import (
 	"errors"

--- a/provisioning_arm64.go
+++ b/provisioning_arm64.go
@@ -1,0 +1,13 @@
+package fdeutils
+
+import (
+	"fmt"
+)
+
+func ProvisionTPM(lockoutAuth []byte) error {
+	return fmt.Errorf("ProvisionTPM not implemented on arm64")
+}
+
+func RequestTPMClearUsingPPI() error {
+	return fmt.Errorf("RequestTPMClearUsingPPI not implemented on arm64")
+}


### PR DESCRIPTION
The go-tpm repo uses sysall.SYS_POLL which is not available on
arm64. Why this is used in the upstream repo is unclear. This
fixes the build failure on arm64 by providing stubs for the
relevant code that just error out.