### PR TITLE
Add vendored go-tpm

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,15 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "CgcocRShUgwD/BXX35dGSVWG0Z0=",
+			"origin": "github.com/chrisccoulson/go-tpm",
+			"path": "github.com/google/go-tpm",
+			"revision": "9f5e4eb491faa0e349919e0ab888f9607101834c",
+			"revisionTime": "2019-07-11T10:07:55Z",
+			"tree": true
+		}
+	],
+	"rootPath": "github.com/chrisccoulson/ubuntu-core-fde-utils"
+}


### PR DESCRIPTION
Use a vendored version of go-tpm with a proposed branch still not merged
upstream.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>