### PR TITLE
Use session based parameter encryption

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -7,3 +7,10 @@ import (
 const (
 	srkHandle tpm2.Handle = 0x81000000
 )
+
+var (
+	paramEncryptAlg = tpm2.SymDef{
+		Algorithm: tpm2.AlgorithmAES,
+		KeyBits:   tpm2.SymKeyBitsU{Sym: 128},
+		Mode:      tpm2.SymModeU{Sym: tpm2.AlgorithmCFB}}
+)

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -36,8 +36,8 @@ func TestProvisionTPM(t *testing.T) {
 	if pub.NameAlg != tpm2.AlgorithmSHA256 {
 		t.Errorf("SRK has unexpected name algorithm")
 	}
-	if pub.Attrs != tpm2.AttrFixedTPM | tpm2.AttrFixedParent | tpm2.AttrSensitiveDataOrigin |
-		tpm2.AttrUserWithAuth | tpm2.AttrRestricted | tpm2.AttrDecrypt {
+	if pub.Attrs != tpm2.AttrFixedTPM|tpm2.AttrFixedParent|tpm2.AttrSensitiveDataOrigin|
+		tpm2.AttrUserWithAuth|tpm2.AttrRestricted|tpm2.AttrDecrypt {
 		t.Errorf("SRK has unexpected attributes")
 	}
 	if pub.Params.RSADetail == nil {
@@ -61,7 +61,7 @@ func TestProvisionTPM(t *testing.T) {
 	if pub.Params.RSADetail.Exponent != 0 {
 		t.Errorf("SRK has an unexpected non-default public exponent")
 	}
-	if len(pub.Unique.RSA) != 2048 / 8 {
+	if len(pub.Unique.RSA) != 2048/8 {
 		t.Errorf("SRK has an unexpected RSA public modulus length")
 	}
 
@@ -155,7 +155,7 @@ func TestProvisionStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("ProvisionStatus failed: %v", err)
 	}
-	expected := AttrValidSRK|AttrDAParamsOK|AttrOwnerClearDisabled|AttrLockoutAuthSet
+	expected := AttrValidSRK | AttrDAParamsOK | AttrOwnerClearDisabled | AttrLockoutAuthSet
 	if status != expected {
 		t.Errorf("Unexpected status")
 	}
@@ -168,7 +168,7 @@ func TestProvisionStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("ProvisionStatus failed: %v", err)
 	}
-	expected = AttrValidSRK|AttrDAParamsOK|AttrOwnerClearDisabled
+	expected = AttrValidSRK | AttrDAParamsOK | AttrOwnerClearDisabled
 	if status != expected {
 		t.Errorf("Unexpected status")
 	}
@@ -181,7 +181,7 @@ func TestProvisionStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("ProvisionStatus failed: %v", err)
 	}
-	expected = AttrValidSRK|AttrDAParamsOK
+	expected = AttrValidSRK | AttrDAParamsOK
 	if status != expected {
 		t.Errorf("Unexpected status")
 	}

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -8,12 +8,12 @@ import (
 )
 
 var (
-	useTpm = flag.Bool("use-tpm", false, "")
+	useTpm         = flag.Bool("use-tpm", false, "")
 	tpmPathForTest = flag.String("tpm-path", "/dev/tpm0", "")
 
-	useMssim = flag.Bool("use-mssim", false, "")
-	mssimHost = flag.String("mssim-host", "localhost", "")
-	mssimTpmPort = flag.Uint("mssim-tpm-port", 2321, "")
+	useMssim          = flag.Bool("use-mssim", false, "")
+	mssimHost         = flag.String("mssim-host", "localhost", "")
+	mssimTpmPort      = flag.Uint("mssim-tpm-port", 2321, "")
 	mssimPlatformPort = flag.Uint("mssim-platform-port", 2322, "")
 )
 

--- a/unseal.go
+++ b/unseal.go
@@ -37,7 +37,8 @@ func UnsealKeyFromTPM(tpm tpm2.TPMContext, buf io.Reader) ([]byte, error) {
 	// 3) Begin and execute policy session
 	//  TODO: Actually execute policy assertions
 	sessionContext, err :=
-		tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.AlgorithmSHA256, nil)
+		tpm.StartAuthSession(srkContext, nil, tpm2.SessionTypePolicy, &paramEncryptAlg,
+			tpm2.AlgorithmSHA256, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot start policy session: %v", err)
 	}


### PR DESCRIPTION
This takes advantage of the session based command and response parameter encryption in go-tpm2 for Create, HierarchyChangeAuth and Unseal.