### PR TITLE
Policy tests

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -91,6 +91,17 @@ func initTrialPolicyDigest(alg tpm2.AlgorithmId) tpm2.Digest {
 	return make(tpm2.Digest, digestSize)
 }
 
+func ensureSufficientORDigests(digests tpm2.DigestList) tpm2.DigestList {
+	if len(digests) == 0 {
+		// This is really an error - return nothing here and let the consumer of this handle the error
+		return digests
+	}
+	if len(digests) > 1 {
+		return digests
+	}
+	return tpm2.DigestList{digests[0], digests[0]}
+}
+
 func makePCRSelectionList(alg tpm2.AlgorithmId, index int) tpm2.PCRSelectionList {
 	return tpm2.PCRSelectionList{
 		tpm2.PCRSelection{Hash: alg, Select: tpm2.PCRSelectionData{index}}}
@@ -173,19 +184,13 @@ func computeSubPolicy(alg tpm2.AlgorithmId, input *subPolicyComputeInput) (*subP
 		secureBootORDigests = append(secureBootORDigests, policyDigest)
 	}
 
-	// PolicyOR requires at least 2 digests. To simplify execution, duplicate the digest in the case when
-	// there is only a single one
-	if len(secureBootORDigests) == 1 {
-		secureBootORDigests = append(secureBootORDigests, secureBootORDigests[0])
-	}
-
 	if len(input.grubPCRDigests) == 0 {
 		return nil, nil, fmt.Errorf("cannot generate sub-policy digest: no grub digests provided")
 	}
 	grubORDigests := make(tpm2.DigestList, 0)
 	for _, digest := range input.grubPCRDigests {
 		policyDigest := initTrialPolicyDigest(alg)
-		policyDigest, err := trialPolicyOR(alg, secureBootORDigests)
+		policyDigest, err := trialPolicyOR(alg, ensureSufficientORDigests(secureBootORDigests))
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot generate sub-policy digest: %v", err)
 		}
@@ -198,19 +203,13 @@ func computeSubPolicy(alg tpm2.AlgorithmId, input *subPolicyComputeInput) (*subP
 		grubORDigests = append(grubORDigests, policyDigest)
 	}
 
-	// PolicyOR requires at least 2 digests. To simplify execution, duplicate the digest in the case when
-	// there is only a single one
-	if len(grubORDigests) == 1 {
-		grubORDigests = append(grubORDigests, grubORDigests[0])
-	}
-
 	if len(input.snapModelPCRDigests) == 0 {
 		return nil, nil, fmt.Errorf("cannot generate sub-policy digest: no snap model digests provided")
 	}
 	snapModelORDigests := make(tpm2.DigestList, 0)
 	for _, digest := range input.snapModelPCRDigests {
 		policyDigest := initTrialPolicyDigest(alg)
-		policyDigest, err := trialPolicyOR(alg, grubORDigests)
+		policyDigest, err := trialPolicyOR(alg, ensureSufficientORDigests(grubORDigests))
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot generate sub-policy digest: %v", err)
 		}
@@ -223,14 +222,8 @@ func computeSubPolicy(alg tpm2.AlgorithmId, input *subPolicyComputeInput) (*subP
 		snapModelORDigests = append(snapModelORDigests, policyDigest)
 	}
 
-	// PolicyOR requires at least 2 digests. To simplify execution, duplicate the digest in the case when
-	// there is only a single one
-	if len(snapModelORDigests) == 1 {
-		snapModelORDigests = append(snapModelORDigests, snapModelORDigests[0])
-	}
-
 	policy := initTrialPolicyDigest(alg)
-	policy, err := trialPolicyOR(alg, snapModelORDigests)
+	policy, err := trialPolicyOR(alg, ensureSufficientORDigests(snapModelORDigests))
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot generate final sub-policy digest: %v", err)
 	}
@@ -260,13 +253,7 @@ func computePolicy(alg tpm2.AlgorithmId, input *policyComputeInput) (*policyData
 		subPolicyORDigests = append(subPolicyORDigests, digest)
 	}
 
-	// PolicyOR requires at least 2 digests. To simplify execution, duplicate the digest in the case when
-	// there is only a single one
-	if len(subPolicyORDigests) == 1 {
-		subPolicyORDigests = append(subPolicyORDigests, subPolicyORDigests[0])
-	}
-
-	policy, err := trialPolicyOR(alg, subPolicyORDigests)
+	policy, err := trialPolicyOR(alg, ensureSufficientORDigests(subPolicyORDigests))
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot generate final policy digest: %v", err)
 	}
@@ -282,20 +269,20 @@ func tryExecSubPolicy(tpm tpm2.TPMContext, sessionContext tpm2.ResourceContext, 
 		secureBootPCR)); err != nil {
 		return err
 	}
-	if err := tpm.PolicyOR(sessionContext, input.SecureBootORDigests); err != nil {
+	if err := tpm.PolicyOR(sessionContext, ensureSufficientORDigests(input.SecureBootORDigests)); err != nil {
 		return err
 	}
 	if err := tpm.PolicyPCR(sessionContext, nil, makePCRSelectionList(input.GrubPCRAlg, grubPCR)); err != nil {
 		return err
 	}
-	if err := tpm.PolicyOR(sessionContext, input.GrubORDigests); err != nil {
+	if err := tpm.PolicyOR(sessionContext, ensureSufficientORDigests(input.GrubORDigests)); err != nil {
 		return err
 	}
 	if err := tpm.PolicyPCR(sessionContext, nil, makePCRSelectionList(input.SnapModelPCRAlg,
 		snapModelPCR)); err != nil {
 		return err
 	}
-	if err := tpm.PolicyOR(sessionContext, input.SnapModelORDigests); err != nil {
+	if err := tpm.PolicyOR(sessionContext, ensureSufficientORDigests(input.SnapModelORDigests)); err != nil {
 		return err
 	}
 	return nil
@@ -305,7 +292,8 @@ func executePolicySession(tpm tpm2.TPMContext, sessionContext, pinContext tpm2.R
 	pin string) error {
 	for _, policy := range input.SubPolicyData {
 		if err := tryExecSubPolicy(tpm, sessionContext, &policy); err == nil {
-			if err := tpm.PolicyOR(sessionContext, input.SubPolicyORDigests); err == nil {
+			if err := tpm.PolicyOR(sessionContext,
+				ensureSufficientORDigests(input.SubPolicyORDigests)); err == nil {
 				break
 			}
 		}

--- a/policy.go
+++ b/policy.go
@@ -39,7 +39,7 @@ func (e policySecretError) Error() string {
 	return fmt.Sprintf("cannot execute PolicySecret command: %v", e.err)
 }
 
-type subPolicyInput struct {
+type subPolicyComputeInput struct {
 	secureBootPCRAlg tpm2.AlgorithmId
 	grubPCRAlg       tpm2.AlgorithmId
 	snapModelPCRAlg  tpm2.AlgorithmId
@@ -49,8 +49,8 @@ type subPolicyInput struct {
 	snapModelPCRDigests  tpm2.DigestList
 }
 
-type policyInput struct {
-	subPolicies   []subPolicyInput
+type policyComputeInput struct {
+	subPolicies   []subPolicyComputeInput
 	pinObjectName tpm2.Name
 }
 
@@ -157,7 +157,7 @@ func trialPolicySecret(alg tpm2.AlgorithmId, currentDigest tpm2.Digest, name tpm
 	return h.Sum(nil)
 }
 
-func generateSubPolicy(alg tpm2.AlgorithmId, input subPolicyInput) (*subPolicyData, tpm2.Digest, error) {
+func computeSubPolicy(alg tpm2.AlgorithmId, input *subPolicyComputeInput) (*subPolicyData, tpm2.Digest, error) {
 	if len(input.secureBootPCRDigests) == 0 {
 		return nil, nil, fmt.Errorf("cannot generate sub-policy digest: no secure-boot digests provided")
 	}
@@ -244,7 +244,7 @@ func generateSubPolicy(alg tpm2.AlgorithmId, input subPolicyInput) (*subPolicyDa
 		SnapModelORDigests:  snapModelORDigests}, policy, nil
 }
 
-func generatePolicy(alg tpm2.AlgorithmId, input *policyInput) (*policyData, tpm2.Digest, error) {
+func computePolicy(alg tpm2.AlgorithmId, input *policyComputeInput) (*policyData, tpm2.Digest, error) {
 	if len(input.subPolicies) == 0 {
 		return nil, nil, fmt.Errorf("cannot generate policy: no sub-policies provided")
 	}
@@ -252,7 +252,7 @@ func generatePolicy(alg tpm2.AlgorithmId, input *policyInput) (*policyData, tpm2
 	subPolicyDatas := make([]subPolicyData, 0)
 	subPolicyORDigests := make(tpm2.DigestList, 0)
 	for _, policy := range input.subPolicies {
-		out, digest, err := generateSubPolicy(alg, policy)
+		out, digest, err := computeSubPolicy(alg, &policy)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,199 @@
+package fdeutil
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
+	"testing"
+
+	"github.com/chrisccoulson/go-tpm2"
+)
+
+func computeSha256(data []byte) []byte {
+	h := sha256.Sum256(data)
+	return h[:]
+}
+
+func computeSha512(data []byte) []byte {
+	h := sha512.Sum512(data)
+	return h[:]
+}
+
+func TestComputePolicy(t *testing.T) {
+	pinName, _ := tpm2.MarshalToBytes(tpm2.AlgorithmSHA256, tpm2.RawSlice(computeSha256([]byte("PIN"))))
+
+	var sha256Digests tpm2.DigestList
+	var sha512Digests tpm2.DigestList
+
+	for _, data := range []string{"foo", "bar", "1234", "ABC"} {
+		sha256Digests = append(sha256Digests, tpm2.Digest(computeSha256([]byte(data))))
+		sha512Digests = append(sha512Digests, tpm2.Digest(computeSha512([]byte(data))))
+	}
+
+	for _, data := range []struct {
+		desc   string
+		alg    tpm2.AlgorithmId
+		input  policyComputeInput
+		output tpm2.Digest
+	}{
+		{
+			desc: "Single",
+			alg:  tpm2.AlgorithmSHA256,
+			input: policyComputeInput{
+				subPolicies: []subPolicyComputeInput{
+					{
+						secureBootPCRAlg:     tpm2.AlgorithmSHA256,
+						grubPCRAlg:           tpm2.AlgorithmSHA256,
+						snapModelPCRAlg:      tpm2.AlgorithmSHA256,
+						secureBootPCRDigests: tpm2.DigestList{sha256Digests[0]},
+						grubPCRDigests:       tpm2.DigestList{sha256Digests[1]},
+						snapModelPCRDigests:  tpm2.DigestList{sha256Digests[2]},
+					},
+				},
+				pinObjectName: pinName,
+			},
+			output: tpm2.Digest{0x89, 0x01, 0x95, 0xd3, 0x1c, 0xf2, 0xfa, 0x32, 0x8c, 0x7d, 0xe2, 0xa4,
+				0xcb, 0x32, 0xe6, 0xd3, 0x3e, 0x0a, 0x6a, 0x21, 0x07, 0x20, 0xfe, 0xf5, 0x8e, 0x43,
+				0xd2, 0x07, 0x0f, 0x89, 0x2c, 0x8f},
+		},
+		{
+			desc: "SingleSHA1",
+			alg:  tpm2.AlgorithmSHA1,
+			input: policyComputeInput{
+				subPolicies: []subPolicyComputeInput{
+					{
+						secureBootPCRAlg:     tpm2.AlgorithmSHA256,
+						grubPCRAlg:           tpm2.AlgorithmSHA256,
+						snapModelPCRAlg:      tpm2.AlgorithmSHA256,
+						secureBootPCRDigests: tpm2.DigestList{sha256Digests[0]},
+						grubPCRDigests:       tpm2.DigestList{sha256Digests[1]},
+						snapModelPCRDigests:  tpm2.DigestList{sha256Digests[2]},
+					},
+				},
+				pinObjectName: pinName,
+			},
+			output: tpm2.Digest{0x44, 0x63, 0x4f, 0xdf, 0xf1, 0x9b, 0xd1, 0xe6, 0x3c, 0x09, 0xd0, 0x8e,
+				0x46, 0x7a, 0xec, 0xf7, 0x99, 0x17, 0x78, 0x08},
+		},
+		{
+			desc: "SingleWithSHA512PCRs",
+			alg:  tpm2.AlgorithmSHA256,
+			input: policyComputeInput{
+				subPolicies: []subPolicyComputeInput{
+					{
+						secureBootPCRAlg:     tpm2.AlgorithmSHA512,
+						grubPCRAlg:           tpm2.AlgorithmSHA512,
+						snapModelPCRAlg:      tpm2.AlgorithmSHA512,
+						secureBootPCRDigests: tpm2.DigestList{sha512Digests[0]},
+						grubPCRDigests:       tpm2.DigestList{sha512Digests[1]},
+						snapModelPCRDigests:  tpm2.DigestList{sha512Digests[2]},
+					},
+				},
+				pinObjectName: pinName,
+			},
+			output: tpm2.Digest{0x47, 0x62, 0x25, 0x9f, 0x13, 0x69, 0xef, 0xe7, 0xa6, 0x6e, 0x6b, 0xd5,
+				0x13, 0x0c, 0xd9, 0xd2, 0xe4, 0x77, 0xed, 0x23, 0x1c, 0x83, 0x56, 0xfd, 0x34, 0x8a,
+				0x98, 0xe4, 0xb6, 0x57, 0x7f, 0xdd},
+		},
+		{
+			desc: "SingleSubPolicyWithMultiplePCRValues",
+			alg:  tpm2.AlgorithmSHA256,
+			input: policyComputeInput{
+				subPolicies: []subPolicyComputeInput{
+					{
+						secureBootPCRAlg:     tpm2.AlgorithmSHA256,
+						grubPCRAlg:           tpm2.AlgorithmSHA256,
+						snapModelPCRAlg:      tpm2.AlgorithmSHA512,
+						secureBootPCRDigests: tpm2.DigestList{sha256Digests[0], sha256Digests[1]},
+						grubPCRDigests:       tpm2.DigestList{sha256Digests[3], sha256Digests[2]},
+						snapModelPCRDigests:  tpm2.DigestList{sha512Digests[2]},
+					},
+				},
+				pinObjectName: pinName,
+			},
+			output: tpm2.Digest{0x39, 0xbd, 0xf1, 0x05, 0x85, 0xb1, 0xb5, 0xdb, 0xcd, 0xef, 0xfa, 0x3d,
+				0x45, 0xbd, 0x24, 0xe3, 0x81, 0x95, 0x16, 0x79, 0xf1, 0x9a, 0xc4, 0xa6, 0x56, 0x60,
+				0xdc, 0xba, 0xf2, 0x6b, 0xe8, 0x13},
+		},
+		{
+			desc: "MultipleSubPolicies",
+			alg:  tpm2.AlgorithmSHA256,
+			input: policyComputeInput{
+				subPolicies: []subPolicyComputeInput{
+					{
+						secureBootPCRAlg:     tpm2.AlgorithmSHA256,
+						grubPCRAlg:           tpm2.AlgorithmSHA256,
+						snapModelPCRAlg:      tpm2.AlgorithmSHA256,
+						secureBootPCRDigests: tpm2.DigestList{sha256Digests[0]},
+						grubPCRDigests:       tpm2.DigestList{sha256Digests[1], sha256Digests[2]},
+						snapModelPCRDigests:  tpm2.DigestList{sha256Digests[2]},
+					},
+					{
+						secureBootPCRAlg:     tpm2.AlgorithmSHA256,
+						grubPCRAlg:           tpm2.AlgorithmSHA256,
+						snapModelPCRAlg:      tpm2.AlgorithmSHA256,
+						secureBootPCRDigests: tpm2.DigestList{sha256Digests[1]},
+						grubPCRDigests:       tpm2.DigestList{sha256Digests[2], sha256Digests[3]},
+						snapModelPCRDigests:  tpm2.DigestList{sha256Digests[2]},
+					},
+				},
+				pinObjectName: pinName,
+			},
+			output: tpm2.Digest{0xd2, 0x98, 0x16, 0x82, 0xe2, 0xce, 0x97, 0x32, 0x2f, 0x0c, 0xff, 0xbc,
+				0xa0, 0x3b, 0xba, 0x48, 0xd8, 0xe1, 0x2a, 0x18, 0x82, 0x94, 0xdd, 0x17, 0x99, 0x36,
+				0x33, 0x23, 0x03, 0x5d, 0x2f, 0xdb},
+		},
+	} {
+		t.Run(data.desc, func(t *testing.T) {
+			dataout, policy, err := computePolicy(data.alg, &data.input)
+			if err != nil {
+				t.Fatalf("computePolicy failed: %v", err)
+			}
+			if dataout.Algorithm != data.alg {
+				t.Errorf("Unexpected session algorithm %v", dataout.Algorithm)
+			}
+			if len(dataout.SubPolicyORDigests) != len(data.input.subPolicies) {
+				t.Errorf("Unexpected number of sub policy OR digests")
+			}
+			if len(dataout.SubPolicyData) != len(data.input.subPolicies) {
+				t.Fatalf("Unexpected number of sub policy data structures")
+			}
+			for i := 0; i < len(data.input.subPolicies); i++ {
+				if dataout.SubPolicyData[i].SecureBootPCRAlg !=
+					data.input.subPolicies[i].secureBootPCRAlg {
+					t.Errorf("Unexpected secure boot PCR algorithm %v for index %d",
+						dataout.SubPolicyData[i].SecureBootPCRAlg, i)
+				}
+				if dataout.SubPolicyData[i].GrubPCRAlg != data.input.subPolicies[i].grubPCRAlg {
+					t.Errorf("Unexpected grub PCR algorithm %v for index %d",
+						dataout.SubPolicyData[i].GrubPCRAlg, i)
+				}
+				if dataout.SubPolicyData[i].SnapModelPCRAlg !=
+					data.input.subPolicies[i].snapModelPCRAlg {
+					t.Errorf("Unexpected snap model PCR algorithm %v for index %d",
+						dataout.SubPolicyData[i].SnapModelPCRAlg, i)
+				}
+				digestSize, _ := getDigestSize(data.alg)
+				for _, l := range []tpm2.DigestList{dataout.SubPolicyData[i].SecureBootORDigests,
+					dataout.SubPolicyData[i].GrubORDigests,
+					dataout.SubPolicyData[i].SnapModelORDigests} {
+					for _, digest := range l {
+						if len(digest) != int(digestSize) {
+							t.Errorf("Unexpected digest size")
+						}
+					}
+				}
+				for _, digest := range dataout.SubPolicyORDigests {
+					if len(digest) != int(digestSize) {
+						t.Errorf("Unexpected digest size")
+					}
+				}
+			}
+
+			if !bytes.Equal(data.output, policy) {
+				t.Errorf("Unexpected policy digest returned (got %x, expected %x)", policy,
+					data.output)
+			}
+		})
+	}
+}

--- a/seal.go
+++ b/seal.go
@@ -73,7 +73,7 @@ func SealKeyToTPM(tpm tpm2.TPMContext, dest string, mode SealMode, key []byte) e
 		return fmt.Errorf("cannot read PCR values: %v", err)
 	}
 
-	subPolicy := subPolicyInput{
+	subPolicyComputeIn := subPolicyComputeInput{
 		secureBootPCRAlg: tpm2.AlgorithmSHA256,
 		grubPCRAlg:       tpm2.AlgorithmSHA256,
 		snapModelPCRAlg:  tpm2.AlgorithmSHA256,
@@ -88,11 +88,11 @@ func SealKeyToTPM(tpm tpm2.TPMContext, dest string, mode SealMode, key []byte) e
 		return fmt.Errorf("cannot determine PIN object name: %v", err)
 	}
 
-	policyDataIn := policyInput{
-		subPolicies:   []subPolicyInput{subPolicy},
+	policyComputeIn := policyComputeInput{
+		subPolicies:   []subPolicyComputeInput{subPolicyComputeIn},
 		pinObjectName: pinObjectName}
 
-	policyData, authPolicy, err := generatePolicy(tpm2.AlgorithmSHA256, &policyDataIn)
+	policyData, authPolicy, err := computePolicy(tpm2.AlgorithmSHA256, &policyComputeIn)
 
 	// Define the template for the sealed key object, using the calculated policy digest
 	template := tpm2.Public{

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -17,6 +17,12 @@ var (
 	mssimPlatformPort = flag.Uint("mssim-platform-port", 2322, "")
 )
 
+func flushContext(t *testing.T, tpm tpm2.TPMContext, context tpm2.ResourceContext) {
+	if err := tpm.FlushContext(context); err != nil {
+		t.Errorf("FlushContext failed: %v", err)
+	}
+}
+
 func openTPMSimulatorForTesting(t *testing.T) (tpm2.TPMContext, *tpm2.TctiMssim) {
 	if !*useMssim {
 		t.SkipNow()


### PR DESCRIPTION
This adds tests for computePolicy and executePolicySession.

There's also a couple of renames of internal types, and a cleanup to avoid duplicating digests in the metadata stored on disk.