### PR TITLE
keydata: use snapcore/snapd/osutil instead of renameio

### DIFF
--- a/keydata.go
+++ b/keydata.go
@@ -8,7 +8,9 @@ import (
 	"io"
 
 	"github.com/chrisccoulson/go-tpm2"
-	"github.com/google/renameio"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/sys"
 )
 
 const (
@@ -131,21 +133,17 @@ func (d *keyData) loadAndIntegrityCheck(buf io.Reader, tpm tpm2.TPMContext,
 }
 
 func (d *keyData) writeToFile(dest string) error {
-	f, err := renameio.TempFile("", dest)
+	f, err := osutil.NewAtomicFile(dest, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
 	if err != nil {
-		return fmt.Errorf("cannot open temporary file: %v", err)
+		return err
 	}
-	defer f.Cleanup()
-
-	if err := f.Chmod(0600); err != nil {
-		return fmt.Errorf("cannot set permissions on temporary file: %v", err)
-	}
+	defer f.Cancel()
 
 	if err := tpm2.MarshalToWriter(f, currentVersion, d); err != nil {
 		return fmt.Errorf("cannot marshal key data to temporary file: %v", err)
 	}
 
-	if err := f.CloseAtomicallyReplace(); err != nil {
+	if err := f.Commit(); err != nil {
 		return fmt.Errorf("cannot atomically replace file: %v", err)
 	}
 


### PR DESCRIPTION
This PR switches to use the snapd code to handle the writing of
the keydata. Adding extra dependencies (like renameio) in snapd
is problematic because it builds on all distros so we always
need to make sure the depdencies are available. For this use-case
it seems like our snapd code is equally well suited like renameio.