### PR TITLE
keydata: initial unit test

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdeutil
+
+import (
+	"github.com/chrisccoulson/go-tpm2"
+)
+
+func NewKeydata() *keyData {
+	// XXX: mock this so that its actually useful and can be marshalled
+	return &keyData{
+		KeyPrivate:        []byte("key-private"),
+		KeyPublic:         &tpm2.Public{},
+		KeyCreationData:   &tpm2.CreationData{},
+		KeyCreationTicket: &tpm2.TkCreation{},
+		PinPublic:         &tpm2.Public{},
+	}
+}
+
+func (k *keyData) WriteToFile(dest string) error {
+	return k.writeToFile(dest)
+}

--- a/keydata.go
+++ b/keydata.go
@@ -8,7 +8,9 @@ import (
 	"io"
 
 	"github.com/chrisccoulson/go-tpm2"
-	"github.com/google/renameio"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/sys"
 )
 
 const (
@@ -131,21 +133,17 @@ func (d *keyData) loadAndIntegrityCheck(buf io.Reader, tpm tpm2.TPMContext,
 }
 
 func (d *keyData) writeToFile(dest string) error {
-	f, err := renameio.TempFile("", dest)
+	f, err := osutil.NewAtomicFile(dest, 0600, 0, sys.UserID(osutil.NoChown), sys.GroupID(osutil.NoChown))
 	if err != nil {
-		return fmt.Errorf("cannot open temporary file: %v", err)
+		return err
 	}
-	defer f.Cleanup()
-
-	if err := f.Chmod(0600); err != nil {
-		return fmt.Errorf("cannot set permissions on temporary file: %v", err)
-	}
+	defer f.Cancel()
 
 	if err := tpm2.MarshalToWriter(f, currentVersion, d); err != nil {
 		return fmt.Errorf("cannot marshal key data to temporary file: %v", err)
 	}
 
-	if err := f.CloseAtomicallyReplace(); err != nil {
+	if err := f.Commit(); err != nil {
 		return fmt.Errorf("cannot atomically replace file: %v", err)
 	}
 

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2019 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package fdeutil_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/chrisccoulson/ubuntu-core-fde-utils"
+)
+
+func TestInitCheckV1(t *testing.T) { TestingT(t) }
+
+type keydataSuite struct{}
+
+var _ = Suite(&keydataSuite{})
+
+func (s *keydataSuite) TestWriteFileUnhappy(c *C) {
+	kd := fdeutil.NewKeydata()
+	kd.PinFlags = 0x1
+
+	dest := filepath.Join(c.MkDir(), "keydata")
+	err := kd.WriteToFile(dest)
+	c.Assert(err, ErrorMatches, "cannot marshal key data .*")
+
+	_, err = ioutil.ReadFile(dest)
+	c.Check(err, ErrorMatches, "open .*/keydata: no such file or directory")
+}
+
+// XXX: write a tests where something is marshalled


### PR DESCRIPTION
When doing https://github.com/chrisccoulson/ubuntu-core-fde-utils/pull/18 I realized that it would be nice to have a unit test so that I can be more confident in my changes. This build on top pr #18.

This is a first start of a unit-test. It uses some patterns we use in the snapd codebase and it would be great if we could (slowly) converge:
- use of gopkg.in/check.v1 for more test convenience
- use of the "fdeutil_test" / "export_test.go" pattern to keep implementation details hidden from the tests

It also seems like the existing tests are mostly integration tests (but I may be wrong I started started looking at things here :) that need a real TPM or a simulated TPM. I would love if we could separate traditional unit tests (like this one) from integration tests. Maybe in a subdir. And then we could use spread for those. We would need to make sure we have VMs that provide TPMs - we use GCE right now so we need to figure that out. For qemu (which is also supported by spread) this should work via the swtpm hopefully. But we will probably have to tweak the spread.yaml to pass the right parameters to spread (or maybe we need a qemu-tpm snap that integrates swtpm/qemu and runs them when runing "qemu").