### PR TITLE
Revoke old authorization policies when new ones are created

### DIFF
--- a/pin_test.go
+++ b/pin_test.go
@@ -54,9 +54,10 @@ func TestChangePIN(t *testing.T) {
 
 	dest := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, dest, Create, nil, key); err != nil {
+	if err := SealKeyToTPM(tpm, Create, dest, policyRevocationIndex, nil, key, nil); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
+	defer deleteKey(t, tpm, dest)
 
 	testPIN := "1234"
 

--- a/policy.go
+++ b/policy.go
@@ -48,10 +48,9 @@ const (
 	secureBootPCR = 7
 	grubPCR       = 8
 	snapModelPCR  = 11
-)
 
-var policySecretAuthFailError = errors.New("cannot execute PolicySecret assertion: the authorization HMAC check " +
-	"failed and DA counter incremented")
+	nvIndexBase tpm2.Handle = 0x018f0000
+)
 
 type policyComputeInput struct {
 	secureBootPCRAlg     tpm2.AlgorithmId
@@ -61,6 +60,8 @@ type policyComputeInput struct {
 	grubPCRDigests       tpm2.DigestList
 	snapModelPCRDigests  tpm2.DigestList
 	pinObjectName        tpm2.Name
+	policyRevokeContext  tpm2.ResourceContext
+	policyRevokeCount    uint64
 }
 
 type policyData struct {
@@ -71,6 +72,8 @@ type policyData struct {
 	SecureBootORDigests tpm2.DigestList
 	GrubORDigests       tpm2.DigestList
 	SnapModelORDigests  tpm2.DigestList
+	PolicyRevokeHandle  tpm2.Handle
+	PolicyRevokeCount   uint64
 }
 
 func hashAlgToGoHash(hashAlg tpm2.AlgorithmId) hash.Hash {
@@ -87,6 +90,30 @@ func getDigestSize(alg tpm2.AlgorithmId) uint {
 		panic("Unknown digest algorithm")
 	}
 	return uint(known.size)
+}
+
+func createPolicyRevocationNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, ownerAuth interface{}) (
+	tpm2.ResourceContext, error) {
+	public := tpm2.NVPublic{
+		Index:   handle,
+		NameAlg: tpm2.AlgorithmSHA256,
+		Attrs:   tpm2.MakeNVAttributes(tpm2.AttrNVAuthWrite|tpm2.AttrNVAuthRead, tpm2.NVTypeCounter),
+		Size:    8}
+
+	if err := tpm.NVDefineSpace(tpm2.HandleOwner, nil, &public, ownerAuth); err != nil {
+		return nil, fmt.Errorf("cannot define NV space: %v", err)
+	}
+
+	context, err := tpm.WrapHandle(handle)
+	if err != nil {
+		return nil, fmt.Errorf("cannot obtain context for new NV index: %v", err)
+	}
+
+	if err := tpm.NVIncrement(context, context, nil); err != nil {
+		return nil, fmt.Errorf("cannot increment new NV index: %v", err)
+	}
+
+	return context, nil
 }
 
 func initTrialPolicyDigest(alg tpm2.AlgorithmId) tpm2.Digest {
@@ -171,6 +198,24 @@ func trialPolicySecret(alg tpm2.AlgorithmId, currentDigest tpm2.Digest, name tpm
 	return h.Sum(nil)
 }
 
+func trialPolicyNV(alg tpm2.AlgorithmId, currentDigest tpm2.Digest, operandB tpm2.Operand, offset uint16,
+	operation tpm2.ArithmeticOp, name tpm2.Name) tpm2.Digest {
+	h := hashAlgToGoHash(alg)
+	h.Write(operandB)
+	binary.Write(h, binary.BigEndian, offset)
+	binary.Write(h, binary.BigEndian, operation)
+
+	args := h.Sum(nil)
+
+	h = hashAlgToGoHash(alg)
+	h.Write(currentDigest)
+	binary.Write(h, binary.BigEndian, tpm2.CommandPolicyNV)
+	h.Write(args)
+	h.Write(name)
+
+	return h.Sum(nil)
+}
+
 func computePolicy(alg tpm2.AlgorithmId, input *policyComputeInput) (*policyData, tpm2.Digest, error) {
 	if len(input.secureBootPCRDigests) == 0 {
 		return nil, nil, errors.New("no secure-boot digests provided")
@@ -233,6 +278,11 @@ func computePolicy(alg tpm2.AlgorithmId, input *policyComputeInput) (*policyData
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot execute PolicyOR of snap model digests: %v", err)
 	}
+
+	operandB := make([]byte, 8)
+	binary.BigEndian.PutUint64(operandB, input.policyRevokeCount)
+	policy = trialPolicyNV(alg, policy, operandB, 0, tpm2.OpUnsignedLE, input.policyRevokeContext.Name())
+
 	policy = trialPolicySecret(alg, policy, input.pinObjectName, nil)
 
 	return &policyData{Algorithm: alg,
@@ -241,7 +291,9 @@ func computePolicy(alg tpm2.AlgorithmId, input *policyComputeInput) (*policyData
 		SnapModelPCRAlg:     input.snapModelPCRAlg,
 		SecureBootORDigests: secureBootORDigests,
 		GrubORDigests:       grubORDigests,
-		SnapModelORDigests:  snapModelORDigests}, policy, nil
+		SnapModelORDigests:  snapModelORDigests,
+		PolicyRevokeHandle:  input.policyRevokeContext.Handle(),
+		PolicyRevokeCount:   input.policyRevokeCount}, policy, nil
 }
 
 func swallowPolicyORValueError(err error) error {
@@ -297,6 +349,24 @@ func executePolicySession(tpm *tpm2.TPMContext, sessionContext, pinContext tpm2.
 		return fmt.Errorf("cannot execute PCR assertions: %v", err)
 	}
 
+	policyRevokeContext, err := tpm.WrapHandle(input.PolicyRevokeHandle)
+	if err != nil {
+		return fmt.Errorf("cannot create context for policy revocation NV index: %v", err)
+	}
+
+	operandB := make([]byte, 8)
+	binary.BigEndian.PutUint64(operandB, input.PolicyRevokeCount)
+	if err := tpm.PolicyNV(policyRevokeContext, policyRevokeContext, sessionContext, operandB, 0,
+		tpm2.OpUnsignedLE, nil); err != nil {
+		switch e := err.(type) {
+		case tpm2.TPMError:
+			if e.Code == tpm2.ErrorPolicy {
+				return ErrPolicyRevoked
+			}
+		}
+		return fmt.Errorf("cannot execute PolicyNV assertion: %v", err)
+	}
+
 	pinSessionContext, err := tpm.StartAuthSession(nil, pinContext, tpm2.SessionTypeHMAC, nil,
 		defaultHashAlgorithm, []byte(pin))
 	if err != nil {
@@ -309,7 +379,7 @@ func executePolicySession(tpm *tpm2.TPMContext, sessionContext, pinContext tpm2.
 		switch e := err.(type) {
 		case tpm2.TPMSessionError:
 			if e.Code == tpm2.ErrorAuthFail {
-				return policySecretAuthFailError
+				return ErrPinFail
 			}
 		}
 		return fmt.Errorf("cannot execute PolicySecret assertion: %v", err)

--- a/policy_test.go
+++ b/policy_test.go
@@ -26,19 +26,6 @@ import (
 	"github.com/chrisccoulson/go-tpm2"
 )
 
-type mockResourceContext struct {
-	handle tpm2.Handle
-	name   tpm2.Name
-}
-
-func (c *mockResourceContext) Handle() tpm2.Handle {
-	return c.handle
-}
-
-func (c *mockResourceContext) Name() tpm2.Name {
-	return c.name
-}
-
 func TestComputePolicy(t *testing.T) {
 	hasher := hashAlgToGoHash(tpm2.AlgorithmSHA256)
 	hasher.Write([]byte("PIN"))
@@ -47,8 +34,7 @@ func TestComputePolicy(t *testing.T) {
 	hasher = hashAlgToGoHash(tpm2.AlgorithmSHA256)
 	hasher.Write([]byte("REVOKE"))
 	revokeIndexName, _ := tpm2.MarshalToBytes(tpm2.AlgorithmSHA256, tpm2.RawBytes(hasher.Sum(nil)))
-
-	policyRevokeContext := &mockResourceContext{handle: 0x0181ffff, name: revokeIndexName}
+	revokeIndexHandle := tpm2.Handle(0x0181ffff)
 
 	digestMatrix := make(map[tpm2.AlgorithmId]tpm2.DigestList)
 
@@ -70,15 +56,16 @@ func TestComputePolicy(t *testing.T) {
 			desc: "Single",
 			alg:  tpm2.AlgorithmSHA256,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA256,
-				grubPCRAlg:           tpm2.AlgorithmSHA256,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA256,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    10,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA256,
+				grubPCRAlg:              tpm2.AlgorithmSHA256,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA256,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: revokeIndexHandle,
+				policyRevokeIndexName:   revokeIndexName,
+				policyRevokeCount:       10,
 			},
 			output: tpm2.Digest{0xa8, 0x14, 0x47, 0x66, 0x4c, 0xbb, 0x32, 0x61, 0x8c, 0x9b, 0x31, 0xfa,
 				0xd6, 0x20, 0xdb, 0xff, 0xba, 0x66, 0x37, 0xdc, 0xbf, 0x85, 0x4e, 0x19, 0xac, 0xf5,
@@ -88,15 +75,16 @@ func TestComputePolicy(t *testing.T) {
 			desc: "SHA1Session",
 			alg:  tpm2.AlgorithmSHA1,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA256,
-				grubPCRAlg:           tpm2.AlgorithmSHA256,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA256,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    4551,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA256,
+				grubPCRAlg:              tpm2.AlgorithmSHA256,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA256,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: revokeIndexHandle,
+				policyRevokeIndexName:   revokeIndexName,
+				policyRevokeCount:       4551,
 			},
 			output: tpm2.Digest{0xf1, 0xe0, 0xaa, 0x57, 0xfc, 0x19, 0x03, 0x86, 0x9a, 0x43, 0xca, 0x5a,
 				0x3a, 0x56, 0xb8, 0x48, 0xe7, 0x7f, 0xe7, 0xc7},
@@ -105,15 +93,16 @@ func TestComputePolicy(t *testing.T) {
 			desc: "SHA256SessionWithSHA512PCRs",
 			alg:  tpm2.AlgorithmSHA256,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA512,
-				grubPCRAlg:           tpm2.AlgorithmSHA512,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA512,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    403,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA512,
+				grubPCRAlg:              tpm2.AlgorithmSHA512,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA512,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: revokeIndexHandle,
+				policyRevokeIndexName:   revokeIndexName,
+				policyRevokeCount:       403,
 			},
 			output: tpm2.Digest{0x77, 0x9b, 0x50, 0x0a, 0x46, 0x37, 0x26, 0x3b, 0xbb, 0xde, 0xa6, 0xe4,
 				0x0d, 0xd1, 0x69, 0x94, 0x7d, 0x2c, 0x4c, 0xff, 0x72, 0xbc, 0x8e, 0xad, 0xf4, 0x86,
@@ -132,10 +121,11 @@ func TestComputePolicy(t *testing.T) {
 				grubPCRDigests: tpm2.DigestList{
 					digestMatrix[tpm2.AlgorithmSHA256][3],
 					digestMatrix[tpm2.AlgorithmSHA256][2]},
-				snapModelPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][2]},
-				pinObjectName:       pinName,
-				policyRevokeContext: policyRevokeContext,
-				policyRevokeCount:   5,
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA512][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: revokeIndexHandle,
+				policyRevokeIndexName:   revokeIndexName,
+				policyRevokeCount:       5,
 			},
 			output: tpm2.Digest{0xb7, 0x15, 0xc1, 0xad, 0x46, 0x47, 0xd6, 0x1d, 0x73, 0x03, 0xb8, 0x26,
 				0xfa, 0x74, 0xc4, 0x72, 0x08, 0x71, 0xc6, 0x83, 0x99, 0x80, 0x4c, 0x9b, 0x4c, 0x89,
@@ -167,6 +157,12 @@ func TestComputePolicy(t *testing.T) {
 			}
 			if len(dataout.SnapModelORDigests) != len(data.input.snapModelPCRDigests) {
 				t.Errorf("Unexpected number of snap model OR digests")
+			}
+			if dataout.PolicyRevokeIndexHandle != data.input.policyRevokeIndexHandle {
+				t.Errorf("Unexpected policy revocation NV index handle")
+			}
+			if dataout.PolicyRevokeCount != data.input.policyRevokeCount {
+				t.Errorf("Unexpected policy revocation count")
 			}
 
 			digestSize := getDigestSize(data.alg)
@@ -261,15 +257,16 @@ func TestExecutePolicy(t *testing.T) {
 			desc: "Single",
 			alg:  tpm2.AlgorithmSHA256,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA256,
-				grubPCRAlg:           tpm2.AlgorithmSHA256,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA256,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    policyRevokeCount,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA256,
+				grubPCRAlg:              tpm2.AlgorithmSHA256,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA256,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -291,15 +288,16 @@ func TestExecutePolicy(t *testing.T) {
 			desc: "SHA1SessionWithSHA256PCRs",
 			alg:  tpm2.AlgorithmSHA1,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA256,
-				grubPCRAlg:           tpm2.AlgorithmSHA256,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA256,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    policyRevokeCount,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA256,
+				grubPCRAlg:              tpm2.AlgorithmSHA256,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA256,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -321,15 +319,16 @@ func TestExecutePolicy(t *testing.T) {
 			desc: "SHA1Session",
 			alg:  tpm2.AlgorithmSHA1,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA1,
-				grubPCRAlg:           tpm2.AlgorithmSHA1,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA1,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA1][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA1][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA1][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    policyRevokeCount,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA1,
+				grubPCRAlg:              tpm2.AlgorithmSHA1,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA1,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA1][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA1][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA1][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -351,15 +350,16 @@ func TestExecutePolicy(t *testing.T) {
 			desc: "WithPIN",
 			alg:  tpm2.AlgorithmSHA256,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA256,
-				grubPCRAlg:           tpm2.AlgorithmSHA256,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA256,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    policyRevokeCount,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA256,
+				grubPCRAlg:              tpm2.AlgorithmSHA256,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA256,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -383,15 +383,16 @@ func TestExecutePolicy(t *testing.T) {
 			desc: "WithIncorrectPIN",
 			alg:  tpm2.AlgorithmSHA256,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA256,
-				grubPCRAlg:           tpm2.AlgorithmSHA256,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA256,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    policyRevokeCount,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA256,
+				grubPCRAlg:              tpm2.AlgorithmSHA256,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA256,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -422,10 +423,11 @@ func TestExecutePolicy(t *testing.T) {
 					digestMatrix[tpm2.AlgorithmSHA256][0]},
 				grubPCRDigests: tpm2.DigestList{
 					digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:       pinName,
-				policyRevokeContext: policyRevokeContext,
-				policyRevokeCount:   policyRevokeCount,
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -456,10 +458,11 @@ func TestExecutePolicy(t *testing.T) {
 				grubPCRDigests: tpm2.DigestList{
 					digestMatrix[tpm2.AlgorithmSHA256][1],
 					digestMatrix[tpm2.AlgorithmSHA256][3]},
-				snapModelPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:       pinName,
-				policyRevokeContext: policyRevokeContext,
-				policyRevokeCount:   policyRevokeCount,
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -490,10 +493,11 @@ func TestExecutePolicy(t *testing.T) {
 				grubPCRDigests: tpm2.DigestList{
 					digestMatrix[tpm2.AlgorithmSHA256][1],
 					digestMatrix[tpm2.AlgorithmSHA256][3]},
-				snapModelPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:       pinName,
-				policyRevokeContext: policyRevokeContext,
-				policyRevokeCount:   policyRevokeCount,
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -524,10 +528,11 @@ func TestExecutePolicy(t *testing.T) {
 				grubPCRDigests: tpm2.DigestList{
 					digestMatrix[tpm2.AlgorithmSHA256][1],
 					digestMatrix[tpm2.AlgorithmSHA256][3]},
-				snapModelPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:       pinName,
-				policyRevokeContext: policyRevokeContext,
-				policyRevokeCount:   policyRevokeCount,
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount,
 			},
 			pcrEvents: []pcrEvent{
 				{
@@ -549,15 +554,16 @@ func TestExecutePolicy(t *testing.T) {
 			desc: "RevokedPolicy",
 			alg:  tpm2.AlgorithmSHA256,
 			input: policyComputeInput{
-				secureBootPCRAlg:     tpm2.AlgorithmSHA256,
-				grubPCRAlg:           tpm2.AlgorithmSHA256,
-				snapModelPCRAlg:      tpm2.AlgorithmSHA256,
-				secureBootPCRDigests: tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
-				grubPCRDigests:       tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
-				snapModelPCRDigests:  tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
-				pinObjectName:        pinName,
-				policyRevokeContext:  policyRevokeContext,
-				policyRevokeCount:    policyRevokeCount - 1,
+				secureBootPCRAlg:        tpm2.AlgorithmSHA256,
+				grubPCRAlg:              tpm2.AlgorithmSHA256,
+				snapModelPCRAlg:         tpm2.AlgorithmSHA256,
+				secureBootPCRDigests:    tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][0]},
+				grubPCRDigests:          tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][1]},
+				snapModelPCRDigests:     tpm2.DigestList{digestMatrix[tpm2.AlgorithmSHA256][2]},
+				pinObjectName:           pinName,
+				policyRevokeIndexHandle: policyRevokeContext.Handle(),
+				policyRevokeIndexName:   policyRevokeContext.Name(),
+				policyRevokeCount:       policyRevokeCount - 1,
 			},
 			pcrEvents: []pcrEvent{
 				{

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/chrisccoulson/go-tpm2"
 )
 
+const (
+	policyRevocationIndex = tpm2.Handle(0x0181ffff)
+)
+
 var (
 	useTpm         = flag.Bool("use-tpm", false, "")
 	tpmPathForTest = flag.String("tpm-path", "/dev/tpm0", "")
@@ -35,6 +39,12 @@ var (
 	mssimTpmPort      = flag.Uint("mssim-tpm-port", 2321, "")
 	mssimPlatformPort = flag.Uint("mssim-platform-port", 2322, "")
 )
+
+func deleteKey(t *testing.T, tpm *tpm2.TPMContext, path string) {
+	if err := DeleteKey(tpm, path, nil); err != nil {
+		t.Errorf("DeleteKey failed: %v", err)
+	}
+}
 
 func flushContext(t *testing.T, tpm *tpm2.TPMContext, context tpm2.ResourceContext) {
 	if err := tpm.FlushContext(context); err != nil {

--- a/unseal.go
+++ b/unseal.go
@@ -28,8 +28,19 @@ import (
 )
 
 var (
+	// ErrLockout is returned from UnsealKeyFromTPM when the TPM is in dictionary-attack lockout mode. Until
+	// the TPM exits lockout mode, the key will need to be recovered via a mechanism that is independent of
+	// the TPM (eg, a recovery key)
 	ErrLockout = errors.New("the TPM is in DA lockout mode")
+
+	// ErrPinFail is returned from UnsealKeyFromTPM when the provided PIN is incorrect.
 	ErrPinFail = errors.New("the provided PIN is incorrect")
+
+	// ErrPolicyRevoked is returned from UnsealKeyFromTPM when the authorization policy for the key has been
+	// revoked. Unless there is another key object with an authorization policy that hasn't been revoked,
+	// the key will need to be recovered via a mechanism that is indepdendent of the TPM (eg, a recovery key).
+	// Once recovered, the key will need to be sealed to the TPM again with a new authorization policy.
+	ErrPolicyRevoked = errors.New("the authorization policy has been revoked")
 )
 
 func UnsealKeyFromTPM(tpm *tpm2.TPMContext, buf io.Reader, pin string) ([]byte, error) {
@@ -68,10 +79,14 @@ func UnsealKeyFromTPM(tpm *tpm2.TPMContext, buf io.Reader, pin string) ([]byte, 
 	defer tpm.FlushContext(sessionContext)
 
 	if err := executePolicySession(tpm, sessionContext, pinContext, data.AuxData.PolicyData, pin); err != nil {
-		if err == policySecretAuthFailError {
-			return nil, ErrPinFail
+		switch err {
+		case ErrPinFail:
+			fallthrough
+		case ErrPolicyRevoked:
+			return nil, err
+		default:
+			return nil, fmt.Errorf("cannot complete execution of policy session: %v", err)
 		}
-		return nil, fmt.Errorf("cannot complete execution of policy session: %v", err)
 	}
 
 	// Unseal

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "G5b4mSiqhTHSZW7W8aNKTrqe1xU=",
+			"checksumSHA1": "5yeUSijCIULhZgfk0ZXrgCN8JUY=",
 			"path": "github.com/chrisccoulson/go-tpm2",
-			"revision": "b12e8f6b8cd13815acd487e6f02984e418dd8f7b",
-			"revisionTime": "2019-09-11T23:50:26Z"
+			"revision": "a2d8d099e1bfc6d70b70f25d6d680ef443bfdcdb",
+			"revisionTime": "2019-10-10T20:26:52Z"
 		},
 		{
 			"checksumSHA1": "PivTtD46tIChYSQcCe153L56W4Y=",


### PR DESCRIPTION
We store the sealed key object and its associated metadata on disk. Updating the authorization policy currently involves resealing the key object and then performing an atomic update of the file on disk. However, we don't make any effort to prevent the old sealed key object with its old policy digest and associated metadata being recovered from the disk even after the original file is unlinked, and there isn't really a 100% reliable way to perform secure deletion of files anyway. Even if there was, there may be copies of the old sealed key object and its associated metadata elsewhere.

One way to resolve this might be to persist the sealed key object and its associated metadata in the TPM. But there are drawbacks with this approach:
- Updating the policy involves persisting a new object which requires owner authorization. We should avoid having to take ownership of the TPM's storage hierarchy in order to perform normal operations, giving device owners the option of taking ownership instead.
- Updating the policy requires a primary key and creating this also requires owner authorization. We currently persist the primary key for this reason, but then this would mean we have to persist 2 objects.
- In addition to the primary key and sealed key object, we have other metadata associated with the key to support the use of a PIN and to support the execution of OR policies. The complete size by default is close to 900bytes already, which is a big chunk of the TPM's available NV storage (and this could be much larger for transient policies that have multiple OR branches during an upgrade - it's entirely possible we could create transient policies with metadata that doesn't fit in a single slot on the TPM).

NV counter indexes have an interesting set of properties that can help us here:
- They can only be incremented. There is no mechanism to decrement them.
- There is no mechanism to roll a counter back by undefining one and then redefining a new counter at the same handle. New counters always start at a value higher than any previous counter value on the TPM.

Using this property of NV counters in combination with the TPM2_PolicyNV assertion allows us to implement policy revocation by reserving a counter and adding an assertion in the authorization policy that the counter is less than or equal to the current counter value + 1. Once the sealed key object and its associated metadata has been atomically updated on disk, the counter is incremented which permanently revokes all authorization policies that have been created previously.