### PR TITLE
Signed authorization policies

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -29,9 +29,9 @@ const (
 
 	// SHA-256 is mandatory to exist on every PC-Client TPM
 	// FIXME: Dynamically select algorithms based on what's available on the device
-	defaultHashAlgorithm   tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
-	sealedKeyNameAlgorithm tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
-	signingKeyNameAlgorithm     tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
+	defaultHashAlgorithm    tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
+	sealedKeyNameAlgorithm  tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
+	signingKeyNameAlgorithm tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
 
 	secureBootPCR       = 7
 	ubuntuBootParamsPCR = 12

--- a/constants.go
+++ b/constants.go
@@ -31,6 +31,7 @@ const (
 	// FIXME: Dynamically select algorithms based on what's available on the device
 	defaultHashAlgorithm   tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
 	sealedKeyNameAlgorithm tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
+	signingKeyNameAlgorithm     tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
 
 	secureBootPCR       = 7
 	ubuntuBootParamsPCR = 12

--- a/errors.go
+++ b/errors.go
@@ -31,8 +31,7 @@ var (
 	ErrRequiresLockoutAuth = errors.New("the TPM indicates the lockout hierarchy has an authorization value, but one hasn't " +
 		"been provided")
 
-	ErrProvisioning  = errors.New("the TPM is not correctly provisioned")
-	ErrKeyFileExists = errors.New("a key data file already exists at the specified path")
+	ErrProvisioning = errors.New("the TPM is not correctly provisioned")
 
 	// ErrLockout is returned from any function when the TPM is in dictionary-attack lockout mode. Until
 	// the TPM exits lockout mode, the key will need to be recovered via a mechanism that is independent of

--- a/examples/get-ek-certificate/get-ek-certificate.go
+++ b/examples/get-ek-certificate/get-ek-certificate.go
@@ -28,6 +28,7 @@ import (
 )
 
 var parentsOnly bool
+
 func init() {
 	flag.BoolVar(&parentsOnly, "parents-only", false, "")
 }

--- a/export_test.go
+++ b/export_test.go
@@ -31,6 +31,6 @@ func NewKeydata() *keyData {
 	}
 }
 
-func (k *keyData) WriteToFile(dest string) error {
-	return k.writeToFile(dest)
-}
+//func (k *keyData) WriteToFile(dest string) error {
+//	return k.writeToFile(dest)
+//}

--- a/keydata_test.go
+++ b/keydata_test.go
@@ -20,13 +20,12 @@
 package fdeutil_test
 
 import (
-	"io/ioutil"
-	"path/filepath"
+	//"io/ioutil"
+	//"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
-
-	"github.com/chrisccoulson/ubuntu-core-fde-utils"
+	//"github.com/chrisccoulson/ubuntu-core-fde-utils"
 )
 
 func TestInitCheckV1(t *testing.T) { TestingT(t) }
@@ -35,16 +34,16 @@ type keydataSuite struct{}
 
 var _ = Suite(&keydataSuite{})
 
-func (s *keydataSuite) TestWriteFile(c *C) {
-	kd := fdeutil.NewKeydata()
-	kd.AskForPinHint = true
+//func (s *keydataSuite) TestWriteFile(c *C) {
+//	kd := fdeutil.NewKeydata()
+//	kd.AskForPinHint = true
 
-	dest := filepath.Join(c.MkDir(), "keydata")
-	err := kd.WriteToFile(dest)
-	c.Assert(err, IsNil)
+//	dest := filepath.Join(c.MkDir(), "keydata")
+//	err := kd.WriteToFile(dest)
+//	c.Assert(err, IsNil)
 
-	_, err = ioutil.ReadFile(dest)
-	c.Check(err, IsNil)
-}
+//	_, err = ioutil.ReadFile(dest)
+//	c.Check(err, IsNil)
+//}
 
 // XXX: write a tests where something is marshalled

--- a/pin.go
+++ b/pin.go
@@ -235,7 +235,7 @@ func ChangePIN(tpm *TPMConnection, path string, oldAuth, newAuth string) error {
 		return fmt.Errorf("cannot load key data file: %v", err)
 	}
 
-	if err := performPINChange(tpm, data.PolicyData.Static.PinIndexHandle, oldAuth, newAuth); err != nil {
+	if err := performPINChange(tpm, data.StaticPolicyData.PinIndexHandle, oldAuth, newAuth); err != nil {
 		return err
 	}
 
@@ -245,7 +245,7 @@ func ChangePIN(tpm *TPMConnection, path string, oldAuth, newAuth string) error {
 		data.AskForPinHint = true
 	}
 
-	if err := data.writeToFile(path); err != nil {
+	if err := data.writeToFileAtomic(path); err != nil {
 		return fmt.Errorf("cannot write key data file: %v", err)
 	}
 

--- a/pin.go
+++ b/pin.go
@@ -21,7 +21,6 @@ package fdeutil
 
 import (
 	"bytes"
-	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/binary"
@@ -60,21 +59,7 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, ownerAuth []byte
 		return nil, xerrors.Errorf("cannot create signing key for initializing NV index: %w", err)
 	}
 
-	keyPublic := tpm2.Public{
-		Type:    tpm2.ObjectTypeRSA,
-		NameAlg: tpm2.HashAlgorithmSHA256,
-		Attrs:   tpm2.AttrSensitiveDataOrigin | tpm2.AttrUserWithAuth | tpm2.AttrSign,
-		Params: tpm2.PublicParamsU{
-			Data: &tpm2.RSAParams{
-				Symmetric: tpm2.SymDefObject{Algorithm: tpm2.SymObjectAlgorithmNull},
-				Scheme: tpm2.RSAScheme{
-					Scheme: tpm2.RSASchemeRSAPSS,
-					Details: tpm2.AsymSchemeU{
-						Data: &tpm2.SigSchemeRSAPSS{HashAlg: tpm2.HashAlgorithmSHA256}}},
-				KeyBits:  2048,
-				Exponent: uint32(key.E)}},
-		Unique: tpm2.PublicIDU{Data: tpm2.PublicKeyRSA(key.N.Bytes())}}
-
+	keyPublic := createPublicAreaForRSASigningKey(&key.PublicKey)
 	keyName, err := keyPublic.Name()
 	if err != nil {
 		return nil, xerrors.Errorf("cannot compute name of signing key for initializing NV index: %w", err)
@@ -140,12 +125,13 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, ownerAuth []byte
 	defer tpm.FlushContext(policySessionContext)
 
 	// Compute a digest for signing with our key
-	h := tpm2.HashAlgorithmSHA256.NewHash()
+	signDigest := tpm2.HashAlgorithmSHA256
+	h := signDigest.NewHash()
 	h.Write(policySessionContext.(tpm2.SessionContext).NonceTPM())
 	binary.Write(h, binary.BigEndian, int32(0))
 
 	// Sign the digest
-	sig, err := rsa.SignPSS(rand.Reader, key, crypto.SHA256, h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+	sig, err := rsa.SignPSS(rand.Reader, key, signDigest.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
 	if err != nil {
 		return nil, xerrors.Errorf("cannot provide signature for initializing NV index: %w", err)
 	}
@@ -153,7 +139,7 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, ownerAuth []byte
 	// Load the public part of the key in to the TPM. There's no integrity protection for this command as if it's altered in
 	// transit then either the signature verification fails or the policy digest will not match the one associated with the NV
 	// index.
-	keyLoaded, _, err := tpm.LoadExternal(nil, &keyPublic, tpm2.HandleEndorsement)
+	keyLoaded, _, err := tpm.LoadExternal(nil, keyPublic, tpm2.HandleEndorsement)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot load public part of key used to initialize NV index to the TPM: %w", err)
 	}
@@ -163,7 +149,7 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, ownerAuth []byte
 		SigAlg: tpm2.SigSchemeAlgRSAPSS,
 		Signature: tpm2.SignatureU{
 			Data: &tpm2.SignatureRSAPSS{
-				Hash: tpm2.HashAlgorithmSHA256,
+				Hash: signDigest,
 				Sig:  tpm2.PublicKeyRSA(sig)}}}
 
 	// Execute the policy assertions
@@ -249,7 +235,7 @@ func ChangePIN(tpm *TPMConnection, path string, oldAuth, newAuth string) error {
 		return fmt.Errorf("cannot load key data file: %v", err)
 	}
 
-	if err := performPINChange(tpm, data.PolicyData.PinIndexHandle, oldAuth, newAuth); err != nil {
+	if err := performPINChange(tpm, data.PolicyData.Static.PinIndexHandle, oldAuth, newAuth); err != nil {
 		return err
 	}
 

--- a/pin_test.go
+++ b/pin_test.go
@@ -46,7 +46,7 @@ func TestChangePIN(t *testing.T) {
 
 	dest := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, dest, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, dest, "", &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, dest)

--- a/pin_test.go
+++ b/pin_test.go
@@ -46,7 +46,7 @@ func TestChangePIN(t *testing.T) {
 
 	dest := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, dest, &testCreationParams, nil, key); err != nil {
+	if err := SealKeyToTPM(tpm, dest, "", &testCreationParams, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, dest)

--- a/policy_test.go
+++ b/policy_test.go
@@ -634,7 +634,7 @@ func TestExecutePolicy(t *testing.T) {
 			}
 			defer flushContext(t, tpm, sessionContext)
 
-			err = executePolicySession(tpm, sessionContext, policyData, data.pinInput)
+			err = executePolicySession(tpm, sessionContext, policyData.Static, policyData.Dynamic, data.pinInput)
 			if data.input.policyRevokeCount < policyRevokeCount {
 				if err == nil {
 					t.Fatalf("Expected an error")

--- a/policy_test.go
+++ b/policy_test.go
@@ -64,7 +64,7 @@ func TestComputeStaticPolicy(t *testing.T) {
 		},
 	} {
 		t.Run(data.desc, func(t *testing.T) {
-			dataout, key, policy, err := computeStaticPolicy(data.alg, &staticPolicyComputeInput{pinIndex: pinIndex})
+			dataout, key, policy, err := computeStaticPolicy(data.alg, &staticPolicyComputeParams{pinIndex: pinIndex})
 			if err != nil {
 				t.Fatalf("computeStaticPolicy failed: %v", err)
 			}
@@ -138,13 +138,13 @@ func TestComputeDynamicPolicy(t *testing.T) {
 	for _, data := range []struct {
 		desc   string
 		alg    tpm2.HashAlgorithmId
-		input  dynamicPolicyComputeInput
+		input  dynamicPolicyComputeParams
 		policy tpm2.Digest
 	}{
 		{
 			desc: "Single",
 			alg:  tpm2.HashAlgorithmSHA256,
-			input: dynamicPolicyComputeInput{
+			input: dynamicPolicyComputeParams{
 				key:                        key,
 				secureBootPCRAlg:           tpm2.HashAlgorithmSHA256,
 				ubuntuBootParamsPCRAlg:     tpm2.HashAlgorithmSHA256,
@@ -159,7 +159,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 		{
 			desc: "SHA1Session",
 			alg:  tpm2.HashAlgorithmSHA1,
-			input: dynamicPolicyComputeInput{
+			input: dynamicPolicyComputeParams{
 				key:                        key,
 				secureBootPCRAlg:           tpm2.HashAlgorithmSHA256,
 				ubuntuBootParamsPCRAlg:     tpm2.HashAlgorithmSHA256,
@@ -174,7 +174,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 		{
 			desc: "SHA256SessionWithSHA512PCRs",
 			alg:  tpm2.HashAlgorithmSHA256,
-			input: dynamicPolicyComputeInput{
+			input: dynamicPolicyComputeParams{
 				key:                        key,
 				secureBootPCRAlg:           tpm2.HashAlgorithmSHA512,
 				ubuntuBootParamsPCRAlg:     tpm2.HashAlgorithmSHA512,
@@ -189,7 +189,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 		{
 			desc: "MultiplePCRValues",
 			alg:  tpm2.HashAlgorithmSHA256,
-			input: dynamicPolicyComputeInput{
+			input: dynamicPolicyComputeParams{
 				key:                    key,
 				secureBootPCRAlg:       tpm2.HashAlgorithmSHA256,
 				ubuntuBootParamsPCRAlg: tpm2.HashAlgorithmSHA256,

--- a/seal.go
+++ b/seal.go
@@ -173,7 +173,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, params *Creat
 
 	// Compute the static policy - this never changes for the lifetime of this key file
 	staticPolicyData, authKey, authPolicy, err :=
-		computeStaticPolicy(sealedKeyNameAlgorithm, &staticPolicyComputeInput{pinIndex: pinIndex})
+		computeStaticPolicy(sealedKeyNameAlgorithm, &staticPolicyComputeParams{pinIndex: pinIndex})
 	if err != nil {
 		return xerrors.Errorf("cannot compute static authorization policy: %w", err)
 	}
@@ -209,7 +209,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, params *Creat
 		return xerrors.Errorf("cannot read revocation counter: %w", err)
 	}
 
-	dynamicPolicyComputeIn := dynamicPolicyComputeInput{
+	dynamicPolicyParams := dynamicPolicyComputeParams{
 		key:                        authKey,
 		secureBootPCRAlg:           pcrAlgorithm,
 		ubuntuBootParamsPCRAlg:     pcrAlgorithm,
@@ -218,7 +218,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, params *Creat
 		policyRevokeIndex:          policyRevokeIndex,
 		policyRevokeCount:          policyRevokeCount}
 
-	dynamicPolicyData, err := computeDynamicPolicy(sealedKeyNameAlgorithm, &dynamicPolicyComputeIn)
+	dynamicPolicyData, err := computeDynamicPolicy(sealedKeyNameAlgorithm, &dynamicPolicyParams)
 	if err != nil {
 		return xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}
@@ -418,7 +418,7 @@ func UpdateKeyAuthPolicy(tpm *TPMConnection, keyPath, privatePath string, params
 	}
 
 	// Use the PCR digests and NV index names to generate a single signed dynamic authorization policy digest
-	policyComputeIn := dynamicPolicyComputeInput{
+	policyParams := dynamicPolicyComputeParams{
 		key:                        authKey,
 		secureBootPCRAlg:           pcrAlgorithm,
 		ubuntuBootParamsPCRAlg:     pcrAlgorithm,
@@ -427,7 +427,7 @@ func UpdateKeyAuthPolicy(tpm *TPMConnection, keyPath, privatePath string, params
 		policyRevokeIndex:          policyRevokeIndex,
 		policyRevokeCount:          nextPolicyRevokeCount}
 
-	policyData, err := computeDynamicPolicy(sealedKeyNameAlgorithm, &policyComputeIn)
+	policyData, err := computeDynamicPolicy(sealedKeyNameAlgorithm, &policyParams)
 	if err != nil {
 		return xerrors.Errorf("cannot compute dynamic authorization policy: %w", err)
 	}

--- a/seal_unseal_test.go
+++ b/seal_unseal_test.go
@@ -271,8 +271,8 @@ func TestUnsealRevoked(t *testing.T) {
 		t.Fatalf("UnsealKeyFromTPM should have failed")
 	}
 	if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: encountered an error whilst executing the "+
-		"authorization policy assertions: cannot execute PolicyNV assertion: TPM returned an error whilst executing command "+
-		"TPM_CC_PolicyNV: TPM_RC_POLICY (policy failure in math operation or an invalid authPolicy value)" {
+		"authorization policy assertions: dynamic authorization policy revocation check failed: TPM returned an error whilst executing "+
+		"command TPM_CC_PolicyNV: TPM_RC_POLICY (policy failure in math operation or an invalid authPolicy value)" {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }
@@ -391,7 +391,10 @@ func TestUnsealPolicyFail(t *testing.T) {
 	if err == nil {
 		t.Fatalf("UnsealKeyFromTPM should have failed")
 	}
-	if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: the authorization policy check failed during unsealing" {
+	if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: encountered an error whilst executing the "+
+		"authorization policy assertions: cannot execute PCR assertions: cannot execute PolicyOR assertion after PolicyPCR assertion "+
+		"against PCR7: TPM returned an error for parameter 1 whilst executing command TPM_CC_PolicyOR: TPM_RC_VALUE (value is out of "+
+		"range or is not correct for the context)" {
 		t.Errorf("Unexpected error: %v", err)
 	}
 }
@@ -819,7 +822,9 @@ func TestCreateAndUnsealWithParams(t *testing.T) {
 											&OSComponent{
 												LoadType: DirectLoadWithShimVerify,
 												Image:    FileOSComponent("testdata/mock.efi.signed.2")}}}}}}}}},
-			err:     "invalid key data file: the authorization policy check failed during unsealing",
+			err: "invalid key data file: encountered an error whilst executing the authorization policy assertions: cannot execute PCR " +
+				"assertions: cannot execute PolicyOR assertion after PolicyPCR assertion against PCR7: TPM returned an error for parameter 1 " +
+				"whilst executing command TPM_CC_PolicyOR: TPM_RC_VALUE (value is out of range or is not correct for the context)",
 			errType: reflect.TypeOf(InvalidKeyFileError{}),
 		},
 	} {

--- a/seal_unseal_test.go
+++ b/seal_unseal_test.go
@@ -53,7 +53,7 @@ func TestCreateAndUnseal(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -93,7 +93,7 @@ func TestCreateDoesntReplace(t *testing.T) {
 	keyFile := tmpDir + "/keydata"
 	privFile := tmpDir + "/keypriv"
 
-	if err := SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -107,7 +107,7 @@ func TestCreateDoesntReplace(t *testing.T) {
 		t.Errorf("Cannot stat private data file: %v", err)
 	}
 
-	err = SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, key)
+	err = SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, nil, key)
 	if err == nil {
 		t.Fatalf("SealKeyToTPM Create should fail if there is already a file with the same path")
 	}
@@ -127,7 +127,7 @@ func TestCreateDoesntReplace(t *testing.T) {
 
 	keyFile2 := tmpDir + "/keydata2"
 
-	err = SealKeyToTPM(tpm, keyFile2, privFile, &testCreationParams, key)
+	err = SealKeyToTPM(tpm, keyFile2, privFile, &testCreationParams, nil, key)
 	if err == nil {
 		t.Fatalf("SealKeyToTPM Create should fail if there is already a file with the same path")
 	}
@@ -165,7 +165,7 @@ func TestUpdateAndUnseal(t *testing.T) {
 	keyFile := tmpDir + "/keydata"
 	privFile := tmpDir + "/keypriv"
 
-	if err := SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -228,7 +228,7 @@ func TestUnsealWithPin(t *testing.T) {
 
 	keyFile := tmpDir + "/keyfile"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -274,7 +274,7 @@ func TestUnsealRevoked(t *testing.T) {
 	keyFile := tmpDir + "/keydata"
 	privFile := tmpDir + "/keypriv"
 
-	if err := SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -324,7 +324,7 @@ func TestUnsealWithWrongPin(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -368,7 +368,7 @@ func TestUnsealPolicyFail(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -413,7 +413,7 @@ func TestUnsealLockout(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer deleteKey(t, tpm, keyFile)
@@ -467,7 +467,7 @@ func TestSealWithProvisioningError(t *testing.T) {
 	}
 
 	run := func(t *testing.T) {
-		err = SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key)
+		err = SealKeyToTPM(tpm, keyFile, "", &testCreationParams, nil, key)
 		if err == nil {
 			t.Fatalf("SealKeyToTPM should have failed")
 		}
@@ -535,7 +535,7 @@ func TestUnsealProvisioningError(t *testing.T) {
 
 	keyFile := tmpDir + "/keydata"
 
-	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, key); err != nil {
+	if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, nil, key); err != nil {
 		t.Fatalf("SealKeyToTPM failed: %v", err)
 	}
 	defer func() {
@@ -840,16 +840,11 @@ func TestCreateAndUnsealWithParams(t *testing.T) {
 			defer os.RemoveAll(tmpDir)
 
 			keyFile := tmpDir + "/keydata"
-			privFile := tmpDir + "/keypriv"
 
-			if err := SealKeyToTPM(tpm, keyFile, privFile, &testCreationParams, key); err != nil {
+			if err := SealKeyToTPM(tpm, keyFile, "", &testCreationParams, data.params, key); err != nil {
 				t.Fatalf("SealKeyToTPM failed: %v", err)
 			}
 			defer deleteKey(t, tpm, keyFile)
-
-			if err := UpdateKeyAuthPolicy(tpm, keyFile, privFile, data.params); err != nil {
-				t.Fatalf("UpdateKeyAuthPolicy failed: %v", err)
-			}
 
 			resetTPMSimulator(t, tpm, tcti)
 			replayLogToTPM(t, tpm, tcti, data.trustedLogPath)

--- a/secureboot_policy.go
+++ b/secureboot_policy.go
@@ -1127,7 +1127,7 @@ func (g *secureBootPolicyGen) buildDbUpdates(keyStores []string) error {
 	return nil
 }
 
-func (g *secureBootPolicyGen) run(params *SealParams, secureBootEvents []classifiedEvent) (tpm2.DigestList, error) {
+func (g *secureBootPolicyGen) run(params *PolicyParams, secureBootEvents []classifiedEvent) (tpm2.DigestList, error) {
 	defer func() {
 		g.loadPaths = nil
 		g.sigDbUpdates = nil
@@ -1210,7 +1210,7 @@ func (g *secureBootPolicyGen) run(params *SealParams, secureBootEvents []classif
 // a new key (and this function is called with both the old and new components present in params) - in
 // which case this can compute multiple digests that can be used in an OR policy to allow updates to be
 // applied atomically.
-func computeSecureBootPolicyDigests(tpm *tpm2.TPMContext, alg tpm2.HashAlgorithmId, params *SealParams) (
+func computeSecureBootPolicyDigests(tpm *tpm2.TPMContext, alg tpm2.HashAlgorithmId, params *PolicyParams) (
 	tpm2.DigestList, error) {
 	logPath := eventLogPath
 	if eventLogPathForTesting != "" {

--- a/secureboot_policy_test.go
+++ b/secureboot_policy_test.go
@@ -413,7 +413,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 		desc    string
 		logPath string
 		efivars string
-		params  *SealParams
+		params  *PolicyParams
 		digests tpm2.DigestList
 		err     string
 	}{
@@ -422,7 +422,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "VerifyFromDbClassic",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -445,7 +445,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "VerifyDirectCASignature",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -468,7 +468,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "VerifyFromDbUC20",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -497,7 +497,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "InvalidGrubSignature",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -519,7 +519,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "NoKernelSignature",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -546,7 +546,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "ShimVerificationDisabled",
 			logPath: "testdata/eventlog2.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -567,7 +567,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "VerifyGrubAndKernelWithShimVendorCert",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -598,7 +598,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "VerifyFromDbUC20_2",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -628,7 +628,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "VerifyFromDbUC20_3",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -659,7 +659,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "KernelKeyRotationUC20",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars2",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -696,7 +696,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "MissingShimVendorCertSection",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -722,7 +722,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "NoShimVendorCert",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -745,7 +745,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "MismatchedNormalAndRecoverySystemsUC20",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -776,7 +776,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "DbxUpdate",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -803,7 +803,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "DbAndDbxUpdate",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -833,7 +833,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "DbUpdateAndKeyRotation",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,
@@ -874,7 +874,7 @@ func TestComputeSecureBootPolicyDigests(t *testing.T) {
 			desc:    "DbUpdateWithNoInitialBootablePaths",
 			logPath: "testdata/eventlog1.bin",
 			efivars: "testdata/efivars1",
-			params: &SealParams{
+			params: &PolicyParams{
 				LoadPaths: []*OSComponent{
 					&OSComponent{
 						LoadType: FirmwareLoad,

--- a/unseal.go
+++ b/unseal.go
@@ -70,7 +70,7 @@ func UnsealKeyFromTPM(tpm *TPMConnection, buf io.Reader, pin string) ([]byte, er
 	}
 	defer tpm.FlushContext(sessionContext)
 
-	if err := executePolicySession(tpm, sessionContext, data.PolicyData, pin); err != nil {
+	if err := executePolicySession(tpm, sessionContext, data.StaticPolicyData, data.DynamicPolicyData, pin); err != nil {
 		var tpmsErr *tpm2.TPMSessionError
 		if xerrors.As(err, &tpmsErr) && tpmsErr.Code() == tpm2.ErrorAuthFail && tpmsErr.Command() == tpm2.CommandPolicySecret {
 			return nil, ErrPinFail

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "WDhVf+3ulWVMsODxtncs/w6d+tM=",
+			"checksumSHA1": "VqAvxeJE9hORJ6vYCC1dFGboZlw=",
 			"path": "github.com/chrisccoulson/go-tpm2",
-			"revision": "eb78fbe1f55339f2ef928a7bc89ce6a3db02bb0b",
-			"revisionTime": "2019-11-14T12:22:19Z"
+			"revision": "698c7fec6160afc27f9839fa4984429bbe1ebbcf",
+			"revisionTime": "2019-12-02T18:42:20Z"
 		},
 		{
 			"checksumSHA1": "emUttBmQY/296swpuBVtuCZ5Ft8=",


### PR DESCRIPTION
The original plan was to store the unsealed key in the kernel keyring so that it can retrieved by an agent in userspace and resealed with a new authorization policy whenever it needed updating. At the moment, SealKeyToTPM operates in 2 modes - creation (where it creates resources such as NV indices), and updating (where it preserves those resources). However, both modes require that the cleartext key is provided, which seems a bit strange because the key would naturally be considered a creation parameter. In reality, both modes are creating a new sealed key object.

TPM's have support for authorization policies that can be updated, using the PolicyAuthorize assertion.

This PR splits the authorization policy in to 2 parts:
- A dynamic part that consists of the PolicyPCR and the PolicyNV revocation counter assertion. This is signed by a key whose private part will live inside the encrypted volume. This part can be updated, as long as the private part of the authorization key can be accessed.
- A static part that consists of a PolicyAuthorize assertion to assert that the approved dynamic policy has been satisfied and that it was signed with the authorized key, and a PolicySecret assertion to assert that the correct PIN has been provided. The static part is the authorization policy that is tied to the sealed key object and never changes.

(I did consider moving the PIN PolicySecret assertion to the dynamic part, but I've got a change that will land in a future PR which piggybacks on to the PIN NV index for making the authorization policy un-satisfiable until the next reset or restart).

With the authorization policy split in to 2 parts, SealKeyToTPM is now split in to 2 functions - SealKeyToTPM which takes a cleartext key and creates a new sealed key object, associated TPM resources and metadata. SealKeyToTPM now writes 2 files - one file containing the sealed key object and metadata required for unsealing that. This file lives outside of the encrypted volume. The second file contains the private part of the authorization key and should live inside the encrypted volume. 

The second function is UpdateKeyAuthPolicy which updates the dynamic part of the authorization policy - this doesn't require knowledge of the cleartext key, but does require access to the private part of the asymmetric key that is authorized to sign the new policy.

Note, this doesn't improve overall security - prior to this PR, a root shell user could access the unsealed key by looking in the root user keyring. Whilst they can't do this now, a root shell user could still use the private part of the authorization key to sign a new dynamic policy that allows the key to be unsealed on future boots by unauthorized software. What it does do though is make it harder for users of the keyring to accidentally leak the key.