### PR TITLE
Data file validation

### DIFF
--- a/keydata.go
+++ b/keydata.go
@@ -219,6 +219,9 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, se
 	if err != nil {
 		return keyFileError{xerrors.Errorf("cannot compute name of dynamic authorization policy key: %w", err)}
 	}
+	if d.StaticPolicyData.AuthorizeKeyPublic.Type != tpm2.ObjectTypeRSA {
+		return keyFileError{errors.New("public area of dynamic authorization policy signing key has the wrong type")}
+	}
 
 	// Make sure that the static authorization policy data is consistent with the sealed key object's policy.
 	trial, _ := tpm2.ComputeAuthPolicy(sealedKeyNameAlgorithm)

--- a/keydata.go
+++ b/keydata.go
@@ -20,9 +20,14 @@
 package fdeutil
 
 import (
+	"bytes"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 
 	"github.com/chrisccoulson/go-tpm2"
 
@@ -157,6 +162,130 @@ func (d *keyData) writeToFileAtomic(dest string) error {
 
 	if err := f.Commit(); err != nil {
 		return xerrors.Errorf("cannot atomically replace file: %w", err)
+	}
+
+	return nil
+}
+
+func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, session *tpm2.Session) error {
+	srkContext, err := tpm.WrapHandle(srkHandle)
+	if err != nil {
+		return xerrors.Errorf("cannot create context for SRK: %w", err)
+	}
+
+	// Load the sealed data object in to the TPM for integrity checking
+	keyContext, _, err := tpm.Load(srkContext, d.KeyPrivate, d.KeyPublic, nil, session.AddAttrs(tpm2.AttrAudit))
+	if err != nil {
+		invalidObject := false
+		switch e := err.(type) {
+		case *tpm2.TPMParameterError:
+			_ = e
+			invalidObject = true
+		case *tpm2.TPMError:
+			if e.Code == tpm2.ErrorSensitive {
+				invalidObject = true
+			}
+		}
+		if invalidObject {
+			return keyFileError{errors.New("bad sealed key object or TPM owner changed")}
+		}
+		return xerrors.Errorf("cannot load sealed key object in to TPM: %w", err)
+	}
+	// It's loaded ok, so we know that the private and public parts are consistent. Flush it right away as we don't need it again.
+	tpm.FlushContext(keyContext)
+
+	// Obtain a ResourceContext for the PIN NV index. Go-tpm2 uses TPM2_NV_ReadPublic without any integrity protection here to
+	// initialize the ResourceContext.
+	pinIndex, err := tpm.WrapHandle(d.StaticPolicyData.PinIndexHandle)
+	if err != nil {
+		if _, unavail := err.(tpm2.ResourceUnavailableError); unavail {
+			return keyFileError{errors.New("PIN NV index is unavailable")}
+		}
+		return xerrors.Errorf("cannot create context for PIN NV index: %w", err)
+	}
+	// Call TPM2_NV_ReadPublic with an audit session for integrity protection purposes and make sure that the returned name matches
+	// the name read back when initializing the ResourceContext.
+	_, pinIndexName, err := tpm.NVReadPublic(pinIndex, session.AddAttrs(tpm2.AttrAudit))
+	if err != nil {
+		return xerrors.Errorf("cannot read public area for PIN NV index: %w", err)
+	}
+	if !bytes.Equal(pinIndexName, pinIndex.Name()) {
+		return keyFileError{errors.New("PIN NV index does not match key data file")}
+	}
+
+	authKeyName, err := d.StaticPolicyData.AuthorizeKeyPublic.Name()
+	if err != nil {
+		return keyFileError{xerrors.Errorf("cannot compute name of dynamic authorization policy key: %w", err)}
+	}
+
+	// Make sure that the static authorization policy data is consistent with the sealed key object's policy.
+	trial, _ := tpm2.ComputeAuthPolicy(sealedKeyNameAlgorithm)
+	trial.PolicyAuthorize(nil, authKeyName)
+	trial.PolicySecret(pinIndex.Name(), nil)
+
+	if !bytes.Equal(trial.GetDigest(), d.KeyPublic.AuthPolicy) {
+		return keyFileError{errors.New("static authorization policy data doesn't match sealed key object")}
+	}
+
+	// Make sure that the dynamic authorization policy signature is valid. We've already verified that the public key is correct
+	// in the previous step.
+	h := signingKeyNameAlgorithm.NewHash()
+	h.Write(d.DynamicPolicyData.AuthorizedPolicy)
+
+	authKey := rsa.PublicKey{
+		N: new(big.Int).SetBytes(d.StaticPolicyData.AuthorizeKeyPublic.Unique.RSA()),
+		E: int(d.StaticPolicyData.AuthorizeKeyPublic.Params.RSADetail().Exponent)}
+	if err := rsa.VerifyPSS(&authKey, signingKeyNameAlgorithm.GetHash(), h.Sum(nil),
+		d.DynamicPolicyData.AuthorizedPolicySignature.Signature.RSAPSS().Sig,
+		&rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash}); err != nil {
+		return keyFileError{xerrors.Errorf("dynamic authorization policy signature verification failed: %w", err)}
+	}
+
+	// Obtain a ResourceContext for the dynamic authorization policy revocation NV index. Go-tpm2 uses TPM2_NV_ReadPublic
+	// without any integrity protection here to initialize the ResourceContext.
+	policyRevokeIndex, err := tpm.WrapHandle(d.DynamicPolicyData.PolicyRevokeIndexHandle)
+	if err != nil {
+		if _, unavail := err.(tpm2.ResourceUnavailableError); unavail {
+			return keyFileError{errors.New("dynamic authorization policy revocation NV index is unavailable")}
+		}
+		return xerrors.Errorf("cannot create context for dynamic authorization policy revocation NV index: %w", err)
+	}
+	// Call TPM2_NV_ReadPublic with an audit session for integrity protection purposes and make sure that the returned name matches
+	// the name read back when initializing the ResourceContext.
+	_, policyRevokeIndexName, err := tpm.NVReadPublic(policyRevokeIndex, session.AddAttrs(tpm2.AttrAudit))
+	if err != nil {
+		return xerrors.Errorf("cannot read public area for dynamic authorization policy revocation NV index: %w", err)
+	}
+	if !bytes.Equal(policyRevokeIndexName, policyRevokeIndex.Name()) {
+		return keyFileError{errors.New("dynamic authorization policy revocation NV index does not match key data file")}
+	}
+
+	// Make sure that the dynamic authorization policy data is consisent with the signed and verified authorized policy digest.
+	trial, _ = tpm2.ComputeAuthPolicy(sealedKeyNameAlgorithm)
+	trial.PolicyOR(ensureSufficientORDigests(d.DynamicPolicyData.UbuntuBootParamsORDigests))
+
+	operandB := make([]byte, 8)
+	binary.BigEndian.PutUint64(operandB, d.DynamicPolicyData.PolicyRevokeCount)
+	trial.PolicyNV(policyRevokeIndex.Name(), operandB, 0, tpm2.OpUnsignedLE)
+
+	if !bytes.Equal(trial.GetDigest(), d.DynamicPolicyData.AuthorizedPolicy) {
+		return keyFileError{errors.New("dynamic authorization policy data doesn't match authorized policy")}
+	}
+
+	if privateData == nil {
+		// If we weren't passed a private data structure, we're done.
+		return nil
+	}
+
+	authKeyPrivate, err := x509.ParsePKCS1PrivateKey(privateData.AuthorizeKeyPrivate)
+	if err != nil {
+		return keyFileError{xerrors.Errorf("cannot parse dynamic policy authorization key: %w", err)}
+	}
+	// Verify that the private data structure is bound to the key data structure.
+	if authKeyPrivate.PublicKey.E != authKey.E || authKeyPrivate.PublicKey.N.Cmp(authKey.N) != 0 ||
+		privateData.PolicyRevokeIndexHandle != d.DynamicPolicyData.PolicyRevokeIndexHandle ||
+		!bytes.Equal(privateData.PolicyRevokeIndexName, policyRevokeIndex.Name()) {
+		return keyFileError{errors.New("key data file and private data file mismatch")}
 	}
 
 	return nil

--- a/keydata.go
+++ b/keydata.go
@@ -210,7 +210,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, se
 		return xerrors.Errorf("cannot read public area for PIN NV index: %w", err)
 	}
 	if !bytes.Equal(pinIndexName, pinIndex.Name()) {
-		return keyFileError{errors.New("PIN NV index does not match key data file")}
+		return errors.New("invalid context for PIN NV index")
 	}
 
 	authKeyName, err := d.StaticPolicyData.AuthorizeKeyPublic.Name()
@@ -257,7 +257,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, se
 		return xerrors.Errorf("cannot read public area for dynamic authorization policy revocation NV index: %w", err)
 	}
 	if !bytes.Equal(policyRevokeIndexName, policyRevokeIndex.Name()) {
-		return keyFileError{errors.New("dynamic authorization policy revocation NV index does not match key data file")}
+		return errors.New("invalid context for dynamic authorization policy revocation NV index")
 	}
 
 	// Make sure that the dynamic authorization policy data is consisent with the signed and verified authorized policy digest.

--- a/policy_test.go
+++ b/policy_test.go
@@ -621,11 +621,11 @@ func TestExecutePolicy(t *testing.T) {
 			}
 
 			if data.pinDefine != "" {
-				if err := performPINChange(tpm, pinIndex.Handle(), "", data.pinDefine); err != nil {
+				if err := performPINChange(tpm, pinIndex, "", data.pinDefine); err != nil {
 					t.Fatalf("performPINChange failed: %v", err)
 				}
 				defer func() {
-					if err := performPINChange(tpm, pinIndex.Handle(), data.pinDefine, ""); err != nil {
+					if err := performPINChange(tpm, pinIndex, data.pinDefine, ""); err != nil {
 						t.Errorf("Resetting PIN failed: %v", err)
 					}
 				}()

--- a/seal.go
+++ b/seal.go
@@ -423,6 +423,14 @@ func UpdateKeyAuthPolicy(tpm *TPMConnection, keyPath, privatePath string, params
 		return InvalidKeyFileError{err.Error()}
 	}
 
+	if err := data.validate(tpm.TPMContext, privateData, session); err != nil {
+		switch e := err.(type) {
+		case keyFileError:
+			return InvalidKeyFileError{"integrity check failed: " + e.err.Error()}
+		}
+		return xerrors.Errorf("cannot integrity check key data file: %w", err)
+	}
+
 	// Compute a new dynamic authorization policy
 	policyData, revoke, err := computeKeyDynamicAuthPolicy(tpm.TPMContext, privateData, params, session)
 	if err != nil {


### PR DESCRIPTION
This adds some validation and consistency checks for the sealed key object file and the private authorization key file when performing PIN changes or authorization policy updates.