### PR TITLE
Store pin policy data on disk

### DIFF
--- a/policy_test.go
+++ b/policy_test.go
@@ -284,7 +284,7 @@ func TestExecutePolicy(t *testing.T) {
 
 	session := tpm2.Session{Context: sessionContext, Attrs: tpm2.AttrContinueSession}
 
-	_, err = createPinNvIndex(tpm.TPMContext, testCreationParams.PinHandle, nil, &session)
+	_, pinIndexKeyName, err := createPinNvIndex(tpm.TPMContext, testCreationParams.PinHandle, nil, &session)
 	if err != nil {
 		t.Fatalf("createPinNvIndex failed: %v", err)
 	}
@@ -621,11 +621,11 @@ func TestExecutePolicy(t *testing.T) {
 			}
 
 			if data.pinDefine != "" {
-				if err := performPINChange(tpm, pinIndex, "", data.pinDefine); err != nil {
+				if err := performPINChange(tpm, pinIndex, pinIndexKeyName, "", data.pinDefine); err != nil {
 					t.Fatalf("performPINChange failed: %v", err)
 				}
 				defer func() {
-					if err := performPINChange(tpm, pinIndex, data.pinDefine, ""); err != nil {
+					if err := performPINChange(tpm, pinIndex, pinIndexKeyName, data.pinDefine, ""); err != nil {
 						t.Errorf("Resetting PIN failed: %v", err)
 					}
 				}()

--- a/seal.go
+++ b/seal.go
@@ -283,7 +283,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 	}
 
 	// Create NV indices
-	pinIndex, err := createPinNvIndex(tpm.TPMContext, create.PinHandle, create.OwnerAuth, session)
+	pinIndex, pinIndexKeyName, err := createPinNvIndex(tpm.TPMContext, create.PinHandle, create.OwnerAuth, session)
 	if err != nil {
 		switch {
 		case isNVIndexDefinedError(err):
@@ -368,6 +368,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 		KeyPrivate:        priv,
 		KeyPublic:         pub,
 		AskForPinHint:     false,
+		PinIndexKeyName:   pinIndexKeyName,
 		StaticPolicyData:  staticPolicyData,
 		DynamicPolicyData: dynamicPolicyData}
 


### PR DESCRIPTION
Store the initialization key name for the pin NV index on disk, rather than storing policy data in the TPM.

A previous change moved a policy digest in to the TPM which might be useful to share a single PIN NV index for multiple sealed data objects, but it's not a requirement and so just store the name of the
initialization key on disk. This can be used to compute the authorization policy OR digests that are required in order to perform PIN changes.