### PR TITLE
Lock down policy revocation index

### DIFF
--- a/policy_test.go
+++ b/policy_test.go
@@ -298,7 +298,11 @@ func TestExecutePolicy(t *testing.T) {
 		}
 	}()
 
-	policyRevokeIndex, err := createPolicyRevocationNvIndex(tpm.TPMContext, testCreationParams.PolicyRevocationHandle, nil, &session)
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey failed: %v", err)
+	}
+	policyRevokeIndex, err := createPolicyRevocationNvIndex(tpm.TPMContext, testCreationParams.PolicyRevocationHandle, key, nil, &session)
 	if err != nil {
 		t.Fatalf("createPolicyRevocationNvIndex failed: %v", err)
 	}


### PR DESCRIPTION
Require authorization to increment the policy revocation NV counter index.

This updates the policy revocation NV counter index so that it requires authorization from the owner of the key used to sign updates to the dynamic authorization policy. This allows the NV index to be locked down by the device owner (by setting the owner authorization, which would prevent the index from being incremented or deleted by anyone without the owner authorization or dynamic policy authorization key).