### PR TITLE
Use alg ids from saved data

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -30,8 +30,6 @@ const (
 	// SHA-256 is mandatory to exist on every PC-Client TPM
 	// FIXME: Dynamically select algorithms based on what's available on the device
 	defaultHashAlgorithm    tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
-	sealedKeyNameAlgorithm  tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
-	signingKeyNameAlgorithm tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
 
 	secureBootPCR       = 7
 	ubuntuBootParamsPCR = 12

--- a/keydata.go
+++ b/keydata.go
@@ -231,7 +231,10 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, se
 	}
 
 	// Make sure that the static authorization policy data is consistent with the sealed key object's policy.
-	trial, _ := tpm2.ComputeAuthPolicy(d.KeyPublic.NameAlg)
+	trial, err := tpm2.ComputeAuthPolicy(d.KeyPublic.NameAlg)
+	if err != nil {
+		return keyFileError{xerrors.Errorf("cannot determine if static authorization policy matches sealed key object: %w", err)}
+	}
 	trial.PolicyAuthorize(nil, authKeyName)
 	trial.PolicySecret(pinIndex.Name(), nil)
 
@@ -241,6 +244,9 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, se
 
 	// Make sure that the name of the key used to initialize the PIN NV index is consistent with the public area of the index.
 	// We've already verified that the NV index is correct in the previous step.
+	if !pinIndexPublic.NameAlg.Supported() {
+		return keyFileError{errors.New("cannot determine if PIN NV index key name is consistent with public area: invalid algorithm")}
+	}
 	policies := pinNvIndexAuthPolicies(pinIndexPublic.NameAlg, d.PinIndexKeyName)
 	trial, _ = tpm2.ComputeAuthPolicy(pinIndexPublic.NameAlg)
 	trial.PolicyOR(policies)

--- a/keydata.go
+++ b/keydata.go
@@ -231,7 +231,7 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, se
 	}
 
 	// Make sure that the static authorization policy data is consistent with the sealed key object's policy.
-	trial, _ := tpm2.ComputeAuthPolicy(sealedKeyNameAlgorithm)
+	trial, _ := tpm2.ComputeAuthPolicy(d.KeyPublic.NameAlg)
 	trial.PolicyAuthorize(nil, authKeyName)
 	trial.PolicySecret(pinIndex.Name(), nil)
 
@@ -241,8 +241,8 @@ func (d *keyData) validate(tpm *tpm2.TPMContext, privateData *privateKeyData, se
 
 	// Make sure that the name of the key used to initialize the PIN NV index is consistent with the public area of the index.
 	// We've already verified that the NV index is correct in the previous step.
-	policies := pinNvIndexAuthPolicies(d.PinIndexKeyName)
-	trial, _ = tpm2.ComputeAuthPolicy(pinNvIndexNameAlgorithm)
+	policies := pinNvIndexAuthPolicies(pinIndexPublic.NameAlg, d.PinIndexKeyName)
+	trial, _ = tpm2.ComputeAuthPolicy(pinIndexPublic.NameAlg)
 	trial.PolicyOR(policies)
 	if !bytes.Equal(trial.GetDigest(), pinIndexPublic.AuthPolicy) {
 		return keyFileError{errors.New("PIN NV index key name is inconsistent with public area")}

--- a/policy.go
+++ b/policy.go
@@ -336,10 +336,13 @@ func executePolicySession(tpm *TPMConnection, sessionContext tpm2.ResourceContex
 
 	authorizeKeyContext, authorizeKeyName, err := tpm.LoadExternal(nil, staticInput.AuthorizeKeyPublic, tpm2.HandleOwner)
 	if err != nil {
-		return xerrors.Errorf("cannot load public area for dynamic authorization policy signature verification: %w", err)
+		return xerrors.Errorf("cannot load public area for dynamic authorization policy signature verification key: %w", err)
 	}
 	defer tpm.FlushContext(authorizeKeyContext)
 
+	if !staticInput.AuthorizeKeyPublic.NameAlg.Supported() {
+		return errors.New("public area of dynamic authorization policy signature verification key has an unsupported name algorithm")
+	}
 	h := staticInput.AuthorizeKeyPublic.NameAlg.NewHash()
 	h.Write(dynamicInput.AuthorizedPolicy)
 

--- a/unseal.go
+++ b/unseal.go
@@ -64,7 +64,7 @@ func UnsealKeyFromTPM(tpm *TPMConnection, buf io.Reader, pin string) ([]byte, er
 	defer tpm.FlushContext(keyContext)
 
 	// Begin and execute policy session
-	sessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, defaultHashAlgorithm, nil)
+	sessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, data.KeyPublic.NameAlg, nil)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot start policy session: %w", err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -49,7 +49,7 @@ func isLockoutError(err error) bool {
 func createPublicAreaForRSASigningKey(key *rsa.PublicKey) *tpm2.Public {
 	return &tpm2.Public{
 		Type:    tpm2.ObjectTypeRSA,
-		NameAlg: signingKeyNameAlgorithm,
+		NameAlg: tpm2.HashAlgorithmSHA256,
 		Attrs:   tpm2.AttrSensitiveDataOrigin | tpm2.AttrUserWithAuth | tpm2.AttrSign,
 		Params: tpm2.PublicParamsU{
 			Data: &tpm2.RSAParams{


### PR DESCRIPTION
When loading existing files, use the algorithms recorded on disk rather than those hard-coded in the source code. This allows algorithms to be changed in the future without breaking existing objects.