### PR TITLE
Lock after unseal

### DIFF
--- a/examples/unseal-key/unseal-key.go
+++ b/examples/unseal-key/unseal-key.go
@@ -80,7 +80,7 @@ func run() int {
 	}
 	defer tpm.Close()
 
-	key, err := fdeutil.UnsealKeyFromTPM(tpm, in, pin)
+	key, err := fdeutil.UnsealKeyFromTPM(tpm, in, pin, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot unseal key: %v\n", err)
 		return 1

--- a/pin.go
+++ b/pin.go
@@ -78,7 +78,7 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, ownerAuth []byte
 	nvPublic := tpm2.NVPublic{
 		Index:      handle,
 		NameAlg:    nameAlg,
-		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead, tpm2.NVTypeOrdinary),
+		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVReadStClear, tpm2.NVTypeOrdinary),
 		AuthPolicy: trial.GetDigest(),
 		Size:       0}
 

--- a/pin_test.go
+++ b/pin_test.go
@@ -62,7 +62,7 @@ func TestChangePIN(t *testing.T) {
 		t.Fatalf("Failed to open key data file: %v", err)
 	}
 
-	keyUnsealed, err := UnsealKeyFromTPM(tpm, f, testPIN)
+	keyUnsealed, err := UnsealKeyFromTPM(tpm, f, testPIN, false)
 	if err != nil {
 		t.Fatalf("UnsealKeyFromTPM failed: %v", err)
 	}

--- a/policy.go
+++ b/policy.go
@@ -367,3 +367,14 @@ func executePolicySession(tpm *TPMConnection, sessionContext tpm2.ResourceContex
 
 	return nil
 }
+
+func lockAccess(tpm *tpm2.TPMContext, input *staticPolicyData) error {
+	pinIndexContext, err := tpm.WrapHandle(input.PinIndexHandle)
+	if err != nil {
+		return xerrors.Errorf("cannot obtain context for pin NV index: %w", err)
+	}
+	if err := tpm.NVReadLock(pinIndexContext, pinIndexContext, nil); err != nil {
+		return xerrors.Errorf("cannot readlock pin NV index: %w", err)
+	}
+	return nil
+}

--- a/policy.go
+++ b/policy.go
@@ -368,7 +368,7 @@ func executePolicySession(tpm *TPMConnection, sessionContext tpm2.ResourceContex
 	return nil
 }
 
-func lockAccess(tpm *tpm2.TPMContext, input *staticPolicyData) error {
+func lockAccessUntilTPMReset(tpm *tpm2.TPMContext, input *staticPolicyData) error {
 	pinIndexContext, err := tpm.WrapHandle(input.PinIndexHandle)
 	if err != nil {
 		return xerrors.Errorf("cannot obtain context for pin NV index: %w", err)

--- a/policy_test.go
+++ b/policy_test.go
@@ -21,8 +21,10 @@ package fdeutil
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	_ "crypto/sha256"
 	"math/big"
 	"testing"
 
@@ -263,6 +265,130 @@ func TestComputeDynamicPolicy(t *testing.T) {
 				t.Errorf("Invalid authorized policy signature: %v", err)
 			}
 		})
+	}
+}
+
+func TestLockAccess(t *testing.T) {
+	tpm, tcti := openTPMSimulatorForTesting(t)
+	resetTPMSimulator(t, tpm, tcti)
+	defer closeTPM(t, tpm)
+
+	if err := ProvisionTPM(tpm, ProvisionModeFull, nil, nil); err != nil {
+		t.Fatalf("Failed to provision TPM for test: %v", err)
+	}
+
+	sessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypeHMAC, nil, defaultSessionHashAlgorithm, nil)
+	if err != nil {
+		t.Fatalf("StartAuthSession failed: %v", err)
+	}
+	defer flushContext(t, tpm, sessionContext)
+
+	session := tpm2.Session{Context: sessionContext, Attrs: tpm2.AttrContinueSession}
+
+	pinIndex, _, err := createPinNvIndex(tpm.TPMContext, testCreationParams.PinHandle, nil, &session)
+	if err != nil {
+		t.Fatalf("createPinNvIndex failed: %v", err)
+	}
+	defer func() {
+		if err := tpm.NVUndefineSpace(tpm2.HandleOwner, pinIndex, nil); err != nil {
+			t.Errorf("NVUndefineSpace failed: %v", err)
+		}
+	}()
+
+	staticPolicyData, key, policy, err :=
+		computeStaticPolicy(tpm2.HashAlgorithmSHA256, &staticPolicyComputeParams{pinIndex: pinIndex})
+	if err != nil {
+		t.Fatalf("computeStaticPolicy failed: %v", err)
+	}
+
+	policyRevokeIndex, err := createPolicyRevocationNvIndex(tpm.TPMContext, testCreationParams.PolicyRevocationHandle, key, nil, &session)
+	if err != nil {
+		t.Fatalf("createPolicyRevocationNvIndex failed: %v", err)
+	}
+	defer func() {
+		if err := tpm.NVUndefineSpace(tpm2.HandleOwner, policyRevokeIndex, nil); err != nil {
+			t.Errorf("NVUndefineSpace failed: %v", err)
+		}
+	}()
+
+	event := []byte("foo")
+	h := crypto.SHA256.New()
+	h.Write(event)
+	eventDigest := h.Sum(nil)
+
+	h = crypto.SHA256.New()
+	h.Write(make([]byte, crypto.SHA256.Size()))
+	h.Write(eventDigest)
+	pcrDigest := h.Sum(nil)
+
+	var policyRevokeCount uint64
+	if c, err := tpm.NVReadCounter(policyRevokeIndex, policyRevokeIndex, nil); err != nil {
+		t.Fatalf("NVReadCounter failed: %v", err)
+	} else {
+		policyRevokeCount = c
+	}
+
+	dynamicPolicyParams := dynamicPolicyComputeParams{
+		key:                        key,
+		signAlg:                    tpm2.HashAlgorithmSHA256,
+		secureBootPCRAlg:           tpm2.HashAlgorithmSHA256,
+		ubuntuBootParamsPCRAlg:     tpm2.HashAlgorithmSHA256,
+		secureBootPCRDigests:       tpm2.DigestList{pcrDigest},
+		ubuntuBootParamsPCRDigests: tpm2.DigestList{pcrDigest},
+		policyRevokeIndex:          policyRevokeIndex,
+		policyRevokeCount:          policyRevokeCount}
+
+	dynamicPolicyData, err := computeDynamicPolicy(tpm2.HashAlgorithmSHA256, &dynamicPolicyParams)
+	if err != nil {
+		t.Fatalf("computeDynamicPolicy failed: %v", err)
+	}
+
+	for _, p := range []tpm2.Handle{secureBootPCR, ubuntuBootParamsPCR} {
+		if _, err := tpm.PCREvent(p, event, nil); err != nil {
+			t.Fatalf("PCREvent failed: %v", err)
+		}
+	}
+
+	policySessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256, nil)
+	if err != nil {
+		t.Fatalf("StartAuthSession failed: %v", err)
+	}
+	defer flushContext(t, tpm, policySessionContext)
+
+	err = executePolicySession(tpm, policySessionContext, staticPolicyData, dynamicPolicyData, "")
+	if err != nil {
+		t.Errorf("executePolicySession failed: %v", err)
+	}
+
+	digest, err := tpm.PolicyGetDigest(policySessionContext)
+	if err != nil {
+		t.Errorf("PolicyGetDigest failed: %v", err)
+	}
+
+	if !bytes.Equal(digest, policy) {
+		t.Errorf("Unexpected digests")
+	}
+
+	if err := lockAccess(tpm.TPMContext, staticPolicyData); err != nil {
+		t.Errorf("lockAccess failed: %v", err)
+	}
+
+	if err := tpm.PolicyRestart(policySessionContext); err != nil {
+		t.Errorf("PolicyRestart failed: %v", err)
+	}
+
+	err = executePolicySession(tpm, policySessionContext, staticPolicyData, dynamicPolicyData, "")
+	if err != nil {
+		t.Errorf("executePolicySession failed: %v", err)
+	}
+
+	digest, err = tpm.PolicyGetDigest(policySessionContext)
+	if err != nil {
+		t.Errorf("PolicyGetDigest failed: %v", err)
+	}
+
+	if bytes.Equal(digest, policy) {
+		t.Errorf("Unexpected digests")
 	}
 }
 

--- a/unlock/main.go
+++ b/unlock/main.go
@@ -129,7 +129,7 @@ func run() int {
 	reprovisionAttempted := false
 
 RetryUnseal:
-	key, err := fdeutil.UnsealKeyFromTPM(tpm, in, pin)
+	key, err := fdeutil.UnsealKeyFromTPM(tpm, in, pin, false)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Cannot unlock device %s: error unsealing key: %v\n", devicePath, err)
 		ret := unspecifiedErrorExitCode

--- a/unseal.go
+++ b/unseal.go
@@ -87,5 +87,12 @@ func UnsealKeyFromTPM(tpm *TPMConnection, buf io.Reader, pin string) ([]byte, er
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
 	}
 
+	lock := false
+	if lock {
+		if err := lockAccess(tpm.TPMContext, data.StaticPolicyData); err != nil {
+			return nil, fmt.Errorf("cannot lock sealed key object from further access: %v", err)
+		}
+	}
+
 	return key, nil
 }

--- a/unseal.go
+++ b/unseal.go
@@ -28,7 +28,7 @@ import (
 	"golang.org/x/xerrors"
 )
 
-func UnsealKeyFromTPM(tpm *TPMConnection, buf io.Reader, pin string) ([]byte, error) {
+func UnsealKeyFromTPM(tpm *TPMConnection, buf io.Reader, pin string, lock bool) ([]byte, error) {
 	// Check if the TPM is in lockout mode
 	props, err := tpm.GetCapabilityTPMProperties(tpm2.PropertyPermanent, 1)
 	if err != nil {
@@ -87,9 +87,8 @@ func UnsealKeyFromTPM(tpm *TPMConnection, buf io.Reader, pin string) ([]byte, er
 		return nil, xerrors.Errorf("cannot unseal key: %w", err)
 	}
 
-	lock := false
 	if lock {
-		if err := lockAccess(tpm.TPMContext, data.StaticPolicyData); err != nil {
+		if err := lockAccessUntilTPMReset(tpm.TPMContext, data.StaticPolicyData); err != nil {
 			return nil, fmt.Errorf("cannot lock sealed key object from further access: %v", err)
 		}
 	}


### PR DESCRIPTION
Add support for locking the sealed key object after unsealing it by making the authorization policy unsatisfiable until the next TPM reset or TPM restart. This works by piggybacking on to the pin NV index and flipping the readlock bit, which changes the name of the index.