### PR TITLE
Set the key size constraint to 32-bytes in SealKeyToTPM

### DIFF
--- a/pin_test.go
+++ b/pin_test.go
@@ -35,7 +35,7 @@ func TestChangePIN(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestChangePIN_")

--- a/seal.go
+++ b/seal.go
@@ -226,8 +226,8 @@ type CreationParams struct {
 // and the nil value can be passed here.
 func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *CreationParams, policy *PolicyParams, key []byte) error {
 	// Check that the key is the correct length
-	if len(key) != 64 {
-		return fmt.Errorf("expected a key length of 512 bits (got %d)", len(key)*8)
+	if len(key) != 32 {
+		return fmt.Errorf("expected a key length of 256 bits (got %d)", len(key)*8)
 	}
 
 	// Use the HMAC session created when the connection was opened rather than creating a new one.

--- a/seal_unseal_test.go
+++ b/seal_unseal_test.go
@@ -42,7 +42,7 @@ func TestCreateAndUnseal(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestCreateAndUnseal_")
@@ -81,7 +81,7 @@ func TestCreateDoesntReplace(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestCreateDoesntReplace_")
@@ -153,7 +153,7 @@ func TestUpdateAndUnseal(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestUpdateAndUnseal_")
@@ -217,7 +217,7 @@ func TestUnsealWithPin(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestUnsealWithPin_")
@@ -262,7 +262,7 @@ func TestUnsealRevoked(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestUnsealRevoked_")
@@ -325,7 +325,7 @@ func TestUnsealWithWrongPin(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestUnsealWithWrongPin_")
@@ -369,7 +369,7 @@ func TestUnsealPolicyFail(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestUnsealPolicyFail_")
@@ -415,7 +415,7 @@ func TestUnsealLockout(t *testing.T) {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestUnsealLockout_")
@@ -462,7 +462,7 @@ func TestSealWithProvisioningError(t *testing.T) {
 	tpm := openTPMForTesting(t)
 	defer closeTPM(t, tpm)
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestSealWithProvisioningError_")
@@ -537,7 +537,7 @@ func TestUnsealProvisioningError(t *testing.T) {
 	}
 	prepare(t)
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestUnsealProvisioningError_")
@@ -634,7 +634,7 @@ func TestLockAccessAfterUnseal(t *testing.T) {
 	efivarsPathForTesting = "testdata/efivars1"
 	replayLogToTPM(t, tpm, tcti, eventLog)
 
-	key := make([]byte, 64)
+	key := make([]byte, 32)
 	rand.Read(key)
 
 	tmpDir, err := ioutil.TempDir("", "_TestLockAccessAfterUnseal_")
@@ -928,7 +928,7 @@ func TestCreateAndUnsealWithParams(t *testing.T) {
 			eventLogPathForTesting = data.creationLogPath
 			efivarsPathForTesting = data.efivars
 
-			key := make([]byte, 64)
+			key := make([]byte, 32)
 			rand.Read(key)
 
 			tmpDir, err := ioutil.TempDir("", "_TestCreateAndUnsealWithParams_"+data.desc+"_")


### PR DESCRIPTION
The key size constraint was previously set to 64-bytes because we were
sealing the volume key, and 64-bytes is required by AES-XTS-256. Now we
aren't sealing the volume key, and the intermediate key derived from the
KDF and used to decrypt the volume key is 32-bytes. There is no point in
sealing secret that has more entropy than this, so adjust the constraint
accordingly.