### PR TITLE
Update go-tpm2 version

### DIFF
--- a/examples/provision-tpm/provision-tpm.go
+++ b/examples/provision-tpm/provision-tpm.go
@@ -86,18 +86,16 @@ func run() int {
 		mode = fdeutil.ProvisionModeFull
 	}
 
-	if err := fdeutil.ProvisionTPM(tpm, mode, []byte(newLockoutAuth), &fdeutil.ProvisionAuths{Owner: []byte(ownerAuth),
-		Endorsement: []byte(endorsementAuth), Lockout: []byte(lockoutAuth)}); err != nil {
+	tpm.OwnerHandleContext().SetAuthValue([]byte(ownerAuth))
+	tpm.EndorsementHandleContext().SetAuthValue([]byte(endorsementAuth))
+	tpm.LockoutHandleContext().SetAuthValue([]byte(lockoutAuth))
+
+	if err := fdeutil.ProvisionTPM(tpm, mode, []byte(newLockoutAuth)); err != nil {
 		switch err {
 		case fdeutil.ErrClearRequiresPPI:
 			fmt.Fprintf(os.Stderr,
 				"Clearing requires the use of the physical presence interface. Re-run with "+
 					"-request-clear\n")
-		case fdeutil.ErrRequiresLockoutAuth:
-			fmt.Fprintf(os.Stderr,
-				"The TPM indicates that the lockout hierarchy has an authorization value. "+
-					"Either re-run with -lockout-auth <auth> or request to clear the TPM "+
-					"with -request-clear if the authorization value isn't known\n")
 		case fdeutil.ErrLockout:
 			fmt.Fprintf(os.Stderr,
 				"The lockout hierarchy is in dictionary attack lockout mode. Either wait for "+

--- a/examples/seal-key/seal-key.go
+++ b/examples/seal-key/seal-key.go
@@ -155,7 +155,8 @@ func run() int {
 			return 1
 		}
 
-		createParams := fdeutil.CreationParams{PolicyRevocationHandle: policyRevokeHandle, PinHandle: pinHandle, OwnerAuth: []byte(ownerAuth)}
+		createParams := fdeutil.CreationParams{PolicyRevocationHandle: policyRevokeHandle, PinHandle: pinHandle}
+		tpm.OwnerHandleContext().SetAuthValue([]byte(ownerAuth))
 
 		if err := fdeutil.SealKeyToTPM(tpm, keyFile, privFile, &createParams, policyParams, key); err != nil {
 			fmt.Fprintf(os.Stderr, "Cannot seal key to TPM: %v\n", err)

--- a/pin_test.go
+++ b/pin_test.go
@@ -31,7 +31,7 @@ func TestChangePIN(t *testing.T) {
 	tpm := openTPMForTesting(t)
 	defer closeTPM(t, tpm)
 
-	if err := ProvisionTPM(tpm, ProvisionModeFull, nil, nil); err != nil {
+	if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 		t.Fatalf("Failed to provision TPM for test: %v", err)
 	}
 

--- a/provisioning.go
+++ b/provisioning.go
@@ -101,85 +101,62 @@ var (
 		Unique: tpm2.PublicIDU{Data: make(tpm2.PublicKeyRSA, 256)}}
 )
 
-type ProvisionAuths struct {
-	Owner       []byte
-	Endorsement []byte
-	Lockout     []byte
-}
-
 // ProvisionTPM prepares the TPM associated with the tpm parameter for full disk encryption. The mode parameter specifies the
 // behaviour of this function.
 //
 // If mode is not ProvisionModeWithoutLockout, this function performs operations that require knowledge of the lockout hierarchy
-// authorization value. If no authorization value is provided via the Lockout field of the auths parameter but the TPM indicates that
-// the lockout hierarchy authorization value has previously been set, this will return a ErrRequiresLockoutAuth error. In this case,
-// either the function should be called with the lockout hierarchy authorization (if it is known), or the TPM must be cleared via the
-// physical presence interface by calling RequestTPMClearUsingPPI and performing a system restart. If the wrong lockout hierarchy
-// authorization value is provided, then a AuthFailError error will be returned. If this happens, the TPM will have entered dictionary
-// attack lockout mode for the lockout hierarchy. Further calls will result in a ErrLockout error being returned. The only way to
-// recover from this is to either wait for the pre-programmed recovery time to expire, or to clear the TPM via the physical presence
-// interface.
+// authorization value, which must be provided by calling TPMConnection.LockoutHandleContext().SetAuthValue() prior to this call.
+// If the wrong lockout hierarchy authorization value is provided, then a AuthFailError error will be returned. If this happens,
+// the TPM will have entered dictionary attack lockout mode for the lockout hierarchy. Further calls will result in a ErrLockout
+// error being returned. The only way to recover from this is to either wait for the pre-programmed recovery time to expire, or to
+// clear the TPM via the physical presence interface.
 //
 // If mode is ProvisionModeClear, this function will attempt to clear the TPM before provisioning it. If owner clear has been disabled
 // (which will be the case if the TPM has previously been provisioned with this function), then ErrClearRequiresPPI will be returned.
 // In this case, the TPM must be cleared via the physical presence interface by calling RequestTPMClearUsingPPI and performing a
 // system restart.
 //
-// This function will create and persist an endorsement key, which requires knowledge of the authorization values for the storage
-// and endorsement hierarchies. If called with mode set to ProvisionModeClear, or if called just after clearing the TPM via the
-// physical presence interface, the authorization values for these hierarchies will be empty at the point that they are required. If
-// called with any other mode and if the authorization values have previously been set, they will need to be provided via the Owner
-// and Endorsement fields of the auths parameter. If the wrong value is provided for either authorization, then a AuthFailError
-// error will be returned. If the correct authorization values are not known, then the only way to recover from this is to call the
-// function with mode set to ProvisionModeClear. If there is an object already stored at the location used for the endorsement key
-// then this function will evict it automatically from the TPM.
+// This function will create and persist an endorsement key which requires knowledge of the authorization values for the storage
+// and endorsement hierarchies, . If called with mode set to ProvisionModeClear, or if called just after clearing the TPM via the
+// physical presence interface, the authorization values for these hierarchies will be empty at the point that they are required.
+// If called with any other mode and if the authorization values have previously been set, they will need to be provided by calling
+// TPMConnection.EndorsementHandleContext().SetAuthValue() and TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling
+// this function. If the wrong value is provided for either authorization, then a AuthFailError error will be returned. If the
+// correct authorization values are not known, then the only way to recover from this is to call the function with mode set to
+// ProvisionModeClear. If there is an object already stored at the location used for the endorsement key then this function will
+// evict it automatically from the TPM.
 //
 // This function will create and persist a storage root key, which requires knowledge of the authorization value for the storage
 // hierarchy. If called with mode set to ProvisionModeClear, or if called just after clearing the TPM via the physical presence
 // interface, the authorization value for the storage hierarchy will be empty at the point that it is required. If called with any
-// other mode and if the authorization value for the storage hierarchy has previously been set, it will need to be provided via the
-// Owner field of the auths parameter. If the wrong value is provided for the storage hierarchy authorization, then a AuthFailError
-// error will be returned. If the correct authorization value is not known, then the only way to recover from this is to call the
-// function with mode set to ProvisionModeClear. If there is an object already stored at the location used for the storage root key
-// then this function will evict it automatically from the TPM.
+// other mode and if the authorization value for the storage hierarchy has previously been set, it will need to be provided by calling
+// TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the wrong value is provided for the storage
+// hierarchy authorization, then a AuthFailError error will be returned. If the correct authorization value is not known, then the
+// only way to recover from this is to call the function with mode set to ProvisionModeClear. If there is an object already stored at
+// the location used for the storage root key then this function will evict it automatically from the TPM.
 //
 // If mode is not ProvisionModeWithoutLockout, the authorization value for the lockout hierarchy will be set to newLockoutAuth
-func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte, auths *ProvisionAuths) error {
+func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte) error {
 	status, err := ProvisionStatus(tpm)
 	if err != nil {
 		return xerrors.Errorf("cannot determine the current status: %w", err)
 	}
 
-	var ownerAuth []byte
-	var endorsementAuth []byte
-	var lockoutAuth []byte
-	if auths != nil {
-		ownerAuth = auths.Owner
-		endorsementAuth = auths.Endorsement
-		lockoutAuth = auths.Lockout
-	}
-
-	if mode != ProvisionModeWithoutLockout && status&AttrLockoutAuthSet > 0 && len(lockoutAuth) == 0 {
-		// Don't needlessly trip the lockout hierarchy DA protection, as you only get one attempt
-		// at the lockout hierarchy authorization
-		return ErrRequiresLockoutAuth
-	}
-
 	// Create an initial session for HMAC authorizations
-	sessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypeHMAC, nil, defaultSessionHashAlgorithm, nil)
+	session, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypeHMAC, nil, defaultSessionHashAlgorithm, nil)
 	if err != nil {
 		return xerrors.Errorf("cannot start session: %w", err)
 	}
-	defer tpm.FlushContext(sessionContext)
+	defer tpm.FlushContext(session)
 
-	session := &tpm2.Session{Context: sessionContext, Attrs: tpm2.AttrContinueSession}
+	session.SetAttrs(tpm2.AttrContinueSession)
 
 	if mode == ProvisionModeClear {
 		if status&AttrOwnerClearDisabled > 0 {
 			return ErrClearRequiresPPI
 		}
 
-		if err := tpm.Clear(tpm2.HandleLockout, session.WithAuthValue(lockoutAuth)); err != nil {
+		if err := tpm.Clear(tpm.LockoutHandleContext(), session); err != nil {
 			switch {
 			case isAuthFailError(err):
 				return AuthFailError{tpm2.HandleLockout}
@@ -189,17 +166,13 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 			return xerrors.Errorf("cannot clear the TPM: %w", err)
 		}
 
-		// These values are all clear now
-		lockoutAuth = nil
-		ownerAuth = nil
-		endorsementAuth = nil
 		status = 0
 	}
 
 	// Provision an endorsement key
-	ekContext, err := tpm.WrapHandle(ekHandle)
+	ekContext, err := tpm.CreateResourceContextFromTPM(ekHandle)
 	if err == nil {
-		if _, err := tpm.EvictControl(tpm2.HandleOwner, ekContext, ekHandle, session.WithAuthValue(ownerAuth)); err != nil {
+		if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), ekContext, ekHandle, session); err != nil {
 			if isAuthFailError(err) {
 				return AuthFailError{tpm2.HandleOwner}
 			}
@@ -209,8 +182,7 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 		return xerrors.Errorf("cannot create context for object at handle required by endorsement key: %w", err)
 	}
 
-	ekContext, _, _, _, _, _, err = tpm.CreatePrimary(tpm2.HandleEndorsement, nil, &ekTemplate, nil, nil,
-		session.WithAuthValue(endorsementAuth))
+	ekContext, _, _, _, _, err = tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, &ekTemplate, nil, nil, session)
 	if err != nil {
 		if isAuthFailError(err) {
 			return AuthFailError{tpm2.HandleEndorsement}
@@ -219,7 +191,7 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 	}
 	defer tpm.FlushContext(ekContext)
 
-	if _, err := tpm.EvictControl(tpm2.HandleOwner, ekContext, ekHandle, session.WithAuthValue(ownerAuth)); err != nil {
+	if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), ekContext, ekHandle, session); err != nil {
 		if isAuthFailError(err) {
 			return AuthFailError{tpm2.HandleOwner}
 		}
@@ -228,8 +200,8 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 
 	// Close the existing session and create a new session that's salted with a value protected with the newly provisioned EK.
 	// This will have a symmetric algorithm for parameter encryption during HierarchyChangeAuth.
-	tpm.FlushContext(sessionContext)
-	if err := tpm.init(nil); err != nil {
+	tpm.FlushContext(session)
+	if err := tpm.init(); err != nil {
 		var verifyErr verificationError
 		if xerrors.As(err, &verifyErr) {
 			return TPMVerificationError{fmt.Sprintf("cannot reinitialize TPM connection after provisioning endorsement key: %v", err)}
@@ -239,9 +211,9 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 	session = tpm.HmacSession()
 
 	// Provision a storage root key
-	srkContext, err := tpm.WrapHandle(srkHandle)
+	srkContext, err := tpm.CreateResourceContextFromTPM(srkHandle)
 	if err == nil {
-		if _, err := tpm.EvictControl(tpm2.HandleOwner, srkContext, srkHandle, session.WithAuthValue(ownerAuth)); err != nil {
+		if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), srkContext, srkHandle, session); err != nil {
 			if isAuthFailError(err) {
 				return AuthFailError{tpm2.HandleOwner}
 			}
@@ -251,19 +223,21 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 		return xerrors.Errorf("cannot create context for object at handle required by storage root key: %w", err)
 	}
 
-	srkContext, _, _, _, _, _, err = tpm.CreatePrimary(tpm2.HandleOwner, nil, &srkTemplate, nil, nil, session.WithAuthValue(ownerAuth))
+	transientSrkContext, _, _, _, _, err := tpm.CreatePrimary(tpm.OwnerHandleContext(), nil, &srkTemplate, nil, nil, session)
 	if err != nil {
 		if isAuthFailError(err) {
 			return AuthFailError{tpm2.HandleOwner}
 		}
 		return xerrors.Errorf("cannot create storage root key: %w", err)
 	}
-	defer tpm.FlushContext(srkContext)
+	defer tpm.FlushContext(transientSrkContext)
 
-	if _, err := tpm.EvictControl(tpm2.HandleOwner, srkContext, srkHandle, session.WithAuthValue(ownerAuth)); err != nil {
+	srkContext, err = tpm.EvictControl(tpm.OwnerHandleContext(), transientSrkContext, srkHandle, session)
+	if err != nil {
 		// Owner auth failure would have been caught by CreatePrimary
 		return xerrors.Errorf("cannot make storage root key persistent: %w", err)
 	}
+	tpm.provisionedSrkContext = srkContext
 
 	if mode == ProvisionModeWithoutLockout {
 		return nil
@@ -272,8 +246,7 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 	// Perform actions that require the lockout hierarchy authorization.
 
 	// Set the DA parameters.
-	if err := tpm.DictionaryAttackParameters(tpm2.HandleLockout, maxTries, recoveryTime, lockoutRecovery,
-		session.WithAuthValue(lockoutAuth)); err != nil {
+	if err := tpm.DictionaryAttackParameters(tpm.LockoutHandleContext(), maxTries, recoveryTime, lockoutRecovery, session); err != nil {
 		switch {
 		case isAuthFailError(err):
 			return AuthFailError{tpm2.HandleLockout}
@@ -284,14 +257,14 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte,
 	}
 
 	// Disable owner clear
-	if err := tpm.ClearControl(tpm2.HandleLockout, true, session.WithAuthValue(lockoutAuth)); err != nil {
+	if err := tpm.ClearControl(tpm.LockoutHandleContext(), true, session); err != nil {
 		// Lockout auth failure or lockout mode would have been caught by DictionaryAttackParameters
 		return xerrors.Errorf("cannot disable owner clear: %w", err)
 	}
 
 	// Set the lockout hierarchy authorization.
-	if err := tpm.HierarchyChangeAuth(tpm2.HandleLockout, tpm2.Auth(newLockoutAuth),
-		session.WithAuthValue(lockoutAuth).AddAttrs(tpm2.AttrCommandEncrypt)); err != nil {
+	if err := tpm.HierarchyChangeAuth(tpm.LockoutHandleContext(), tpm2.Auth(newLockoutAuth),
+		session.IncludeAttrs(tpm2.AttrCommandEncrypt)); err != nil {
 		return xerrors.Errorf("cannot set the lockout hierarchy authorization value: %w", err)
 	}
 
@@ -318,14 +291,18 @@ func RequestTPMClearUsingPPI() error {
 // This isn't completely accurate as it does not know if the unique field of the specified template was used to create the object,
 // so it should be used with caution. This function returning true is no guarantee that recreating the object with the specified
 // template would create the same object.
-func isObjectPrimaryKeyWithTemplate(tpm *tpm2.TPMContext, hierarchy tpm2.Handle, context tpm2.ResourceContext,
-	template *tpm2.Public, session *tpm2.Session) (bool, error) {
+func isObjectPrimaryKeyWithTemplate(tpm *tpm2.TPMContext, hierarchy, context tpm2.ResourceContext,
+	template *tpm2.Public, session tpm2.SessionContext) (bool, error) {
 	if session != nil {
-		session = session.AddAttrs(tpm2.AttrAudit)
+		session = session.IncludeAttrs(tpm2.AttrAudit)
 	}
 
 	pub, name, qualifiedName, err := tpm.ReadPublic(context, session)
 	if err != nil {
+		var he *tpm2.TPMHandleError
+		if xerrors.As(err, &he) && he.Code() == tpm2.ErrorHandle {
+			return false, nil
+		}
 		return false, xerrors.Errorf("cannot read public area of object: %w", err)
 	}
 	if !bytes.Equal(name, context.Name()) {
@@ -350,14 +327,12 @@ func isObjectPrimaryKeyWithTemplate(tpm *tpm2.TPMContext, hierarchy tpm2.Handle,
 		}
 	}
 
-	parent, _ := tpm.WrapHandle(hierarchy)
-
 	// Determine if this is a primary key by validating its qualified name. From the spec, the qualified name
 	// of key B (QNb) which is a child of key A is QNb = Hb(QNa || NAMEb). Key A in this case should be
 	// the storage primary seed, which has a qualified name matching its name (and the name is the handle
 	// for the storage hierarchy)
 	h := sha256.New()
-	h.Write(parent.Name())
+	h.Write(hierarchy.Name())
 	h.Write(context.Name())
 
 	alg := make([]byte, 2)
@@ -371,33 +346,29 @@ func isObjectPrimaryKeyWithTemplate(tpm *tpm2.TPMContext, hierarchy tpm2.Handle,
 	return true, nil
 }
 
-func hasValidSRK(tpm *tpm2.TPMContext, session *tpm2.Session) (bool, error) {
-	srkContext, err := tpm.WrapHandle(srkHandle)
-	if err != nil {
-		if _, unavail := err.(tpm2.ResourceUnavailableError); unavail {
-			return false, nil
-		}
-		return false, xerrors.Errorf("cannot obtain context for SRK: %w", err)
-	}
-
-	if ok, err := isObjectPrimaryKeyWithTemplate(tpm, tpm2.HandleOwner, srkContext, &srkTemplate, session); err != nil {
-		return false, xerrors.Errorf("cannot determine if object at SRK handle is a primary key in the storage hierarchy: %w", err)
-	} else if !ok {
-		return false, nil
-	}
-
-	return true, nil
-}
-
 func ProvisionStatus(tpm *TPMConnection) (ProvisionStatusAttributes, error) {
 	var out ProvisionStatusAttributes
 
-	if rc, err := tpm.EkContext(); err == nil && rc.Handle() != tpm2.HandleUnassigned {
+	session := tpm.HmacSession().IncludeAttrs(tpm2.AttrAudit)
+
+	if ek, err := tpm.CreateResourceContextFromTPM(ekHandle, session); err != nil {
+		if _, unavail := err.(tpm2.ResourceUnavailableError); !unavail {
+			return 0, err
+		}
+	} else if ekInit, err := tpm.EkContext(); err == nil && bytes.Equal(ekInit.Name(), ek.Name()) {
 		out |= AttrValidEK
 	}
 
-	if ok, err := hasValidSRK(tpm.TPMContext, tpm.HmacSession()); err != nil {
-		return 0, err
+	if srk, err := tpm.CreateResourceContextFromTPM(srkHandle, session); err != nil {
+		if _, unavail := err.(tpm2.ResourceUnavailableError); !unavail {
+			return 0, err
+		}
+	} else if tpm.provisionedSrkContext != nil {
+		if bytes.Equal(tpm.provisionedSrkContext.Name(), srk.Name()) {
+			out |= AttrValidSRK
+		}
+	} else if ok, err := isObjectPrimaryKeyWithTemplate(tpm.TPMContext, tpm.OwnerHandleContext(), srk, &srkTemplate, tpm.HmacSession()); err != nil {
+		return 0, xerrors.Errorf("cannot determine if object at SRK handle is a primary key in the storage hierarchy: %w", err)
 	} else if ok {
 		out |= AttrValidSRK
 	}

--- a/seal.go
+++ b/seal.go
@@ -133,14 +133,18 @@ type PolicyParams struct {
 }
 
 func computeKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, alg, signAlg tpm2.HashAlgorithmId, privateData *privateKeyData,
-	params *PolicyParams, session *tpm2.Session) (*dynamicPolicyData, error) {
-	// Obtain a ResourceContext for the dynamic policy revocation NV index. Expect the
-	// caller to have already done this, so it can't fail
-	policyRevokeIndex, _ := tpm.WrapHandle(privateData.Data.PolicyRevokeIndexHandle)
+	params *PolicyParams, session tpm2.SessionContext) (*dynamicPolicyData, error) {
+	// Parse the key for signing the dynamic authorization policy.
+	authKey, err := x509.ParsePKCS1PrivateKey(privateData.Data.AuthorizeKeyPrivate)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot parse authorization key: %w", err)
+	}
 
-	// Parse the key for signing the dynamic authorization policy. Expect the caller
-	// to have already made sure this parses correctly, so it can't fail
-	authKey, _ := x509.ParsePKCS1PrivateKey(privateData.Data.AuthorizeKeyPrivate)
+	policyRevokeIndexPub := privateData.Data.PolicyRevokeIndexPublic
+	policyRevokeIndex, err := tpm2.CreateNVIndexResourceContextFromPublic(policyRevokeIndexPub)
+	if err != nil {
+		return nil, xerrors.Errorf("cannot create context for dynamic authorization policy revocation NV index: %w", err)
+	}
 
 	// Obtain the revoke count for the new dynamic authorization policy
 	var nextPolicyRevokeCount uint64
@@ -149,8 +153,6 @@ func computeKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, alg, signAlg tpm2.HashAlg
 	} else {
 		nextPolicyRevokeCount = c + 1
 	}
-
-	var err error
 
 	// Compute PCR digests
 	var secureBootDigests tpm2.DigestList
@@ -184,7 +186,7 @@ func computeKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, alg, signAlg tpm2.HashAlg
 		ubuntuBootParamsPCRAlg:     pcrAlgorithm,
 		secureBootPCRDigests:       secureBootDigests,
 		ubuntuBootParamsPCRDigests: ubuntuBootParamsDigests,
-		policyRevokeIndex:          policyRevokeIndex,
+		policyRevokeIndexPub:       policyRevokeIndexPub,
 		policyRevokeCount:          nextPolicyRevokeCount}
 
 	policyData, err := computeDynamicPolicy(alg, &policyParams)
@@ -198,7 +200,6 @@ func computeKeyDynamicAuthPolicy(tpm *tpm2.TPMContext, alg, signAlg tpm2.HashAlg
 type CreationParams struct {
 	PolicyRevocationHandle tpm2.Handle
 	PinHandle              tpm2.Handle
-	OwnerAuth              []byte
 }
 
 // SealKeyToTPM seals the provided disk encryption key to the storage hierarchy of the TPM. The caller is required to provide a
@@ -210,8 +211,9 @@ type CreationParams struct {
 // If the TPM is not correctly provisioned with a persistent storage root key at the expected location, it will return a
 // ErrProvisioning error. In this case, ProvisionTPM must be called before proceeding.
 //
-// The key will be created with an authorization policy based on the current device state. The authorization policy can be updated
-// with UpdateKeyAuthPolicy.
+// If policy is nil, the key will be created with an authorization policy based on the current device state. The authorization policy
+// can be updated afterwards with UpdateKeyAuthPolicy. If policy is provided, the authorization policy will be computed based on
+// the provided parameters.
 //
 // If there is already a file at either specified path, a wrapped *os.PathError error will be returned with an underlying error of
 // syscall.EEXIST.
@@ -221,9 +223,9 @@ type CreationParams struct {
 // TPMResourceExistsError error will be returned. The handles must be valid NV index handles (MSO == 0x01), and the choice of handle
 // should take in to consideration the reserved indices from the "Registry of reserved TPM 2.0 handles and localities" specification.
 // It is recommended that the handles are in the block reserved for owner objects (0x01800000 - 0x01bfffff). The owner authorization
-// is also required, provided via the OwnerAuth of the CreationParams struct. If the provided owner authorization is incorrect, a
-// AuthFailError error will be returned. On a TPM that has been newly provisioned with ProvisionTPM, the owner authorization is empty
-// and the nil value can be passed here.
+// is also required, provided by calling TPMConnection.OwnerHandleContext().SetAuthValue() prior to calling this function. If the
+// provided owner authorization is incorrect, a AuthFailError error will be returned. On a TPM that has been newly provisioned with
+// ProvisionTPM, the owner authorization is empty and the nil value can be passed here.
 func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *CreationParams, policy *PolicyParams, key []byte) error {
 	// Check that the key is the correct length
 	if len(key) != 64 {
@@ -233,23 +235,27 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 	// Use the HMAC session created when the connection was opened rather than creating a new one.
 	session := tpm.HmacSession()
 
-	// Bail out now if the object at the SRK index obviously isn't a valid primary key with the expected properties, as we know
-	// that a future call to ProvisionTPM will create a different key that makes the sealed key object non-recoverable. If this
-	// succeeds, it doesn't necessarily mean that the object was created with the same template that ProvisionTPM uses, and isn't
-	// a guarantee that a future call to ProvisionTPM would't produce a different key.
-	//
-	// Ideally, initial creation would be performed immediately after ProvisionTPM without closing the TPMConnection, as ProvisionTPM
-	// will cache a ResourceContext for the SRK it creates and if the object is switched out on the TPM for a different one in the
-	// meantime, TPM2_Create will fail later on.
-	if ok, err := hasValidSRK(tpm.TPMContext, session); err != nil {
-		return err
-	} else if !ok {
-		return ErrProvisioning
+	// Obtain a context for the SRK now. If we're called immediately after ProvisionTPM without closing the TPMConnection, we
+	// use the context cached by ProvisionTPM, which corresponds to the object provisioned. If not, the public area is read back
+	// from the TPM and some sanity checks are performed to make sure it looks like a SRK. Note that if this succeeds, it doesn't
+	// guarantee that the returned context corresponds to an object created with the same template that ProvisionTPM uses, and doesn't
+	// guarantee that a future call to ProvisionTPM wouldn't produce a different key.
+	srkContext := tpm.provisionedSrkContext
+	if srkContext == nil {
+		var err error
+		srkContext, err = tpm.CreateResourceContextFromTPM(srkHandle)
+		if err != nil {
+			if _, unavail := err.(tpm2.ResourceUnavailableError); unavail {
+				return ErrProvisioning
+			}
+			return xerrors.Errorf("cannot create context for SRK: %w", err)
+		}
+		if ok, err := isObjectPrimaryKeyWithTemplate(tpm.TPMContext, tpm.OwnerHandleContext(), srkContext, &srkTemplate, tpm.HmacSession()); err != nil {
+			return xerrors.Errorf("cannot determine if object at SRK handle is a primary key in the storage hierarchy: %w", err)
+		} else if !ok {
+			return ErrProvisioning
+		}
 	}
-	// This can't fail now
-	srkContext, _ := tpm.WrapHandle(srkHandle)
-
-	// At this point, we know that the name and public area associated with srkContext correspond to an object on the TPM.
 
 	succeeded := false
 
@@ -283,7 +289,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 	}
 
 	// Create pin NV index
-	pinIndex, pinIndexKeyName, err := createPinNvIndex(tpm.TPMContext, create.PinHandle, create.OwnerAuth, session)
+	pinIndexPub, pinIndexKeyName, err := createPinNvIndex(tpm.TPMContext, create.PinHandle, session)
 	if err != nil {
 		switch {
 		case isNVIndexDefinedError(err):
@@ -297,20 +303,24 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 		if succeeded {
 			return
 		}
-		tpm.NVUndefineSpace(tpm2.HandleOwner, pinIndex, session.WithAuthValue(create.OwnerAuth))
+		index, err := tpm2.CreateNVIndexResourceContextFromPublic(pinIndexPub)
+		if err != nil {
+			return
+		}
+		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, session)
 	}()
 
 	sealedKeyNameAlg := tpm2.HashAlgorithmSHA256
 
 	// Compute the static policy - this never changes for the lifetime of this key file
 	staticPolicyData, authKey, authPolicy, err :=
-		computeStaticPolicy(sealedKeyNameAlg, &staticPolicyComputeParams{pinIndex: pinIndex})
+		computeStaticPolicy(sealedKeyNameAlg, &staticPolicyComputeParams{pinIndexPub: pinIndexPub})
 	if err != nil {
 		return xerrors.Errorf("cannot compute static authorization policy: %w", err)
 	}
 
 	// Create dynamic authorization policy revocation index
-	policyRevokeIndex, err := createPolicyRevocationNvIndex(tpm.TPMContext, create.PolicyRevocationHandle, authKey, create.OwnerAuth, session)
+	policyRevokeIndexPub, err := createPolicyRevocationNvIndex(tpm.TPMContext, create.PolicyRevocationHandle, authKey, session)
 	if err != nil {
 		switch {
 		case isNVIndexDefinedError(err):
@@ -324,7 +334,11 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 		if succeeded {
 			return
 		}
-		tpm.NVUndefineSpace(tpm2.HandleOwner, policyRevokeIndex, session.WithAuthValue(create.OwnerAuth))
+		index, err := tpm2.CreateNVIndexResourceContextFromPublic(policyRevokeIndexPub)
+		if err != nil {
+			return
+		}
+		tpm.NVUndefineSpace(tpm.OwnerHandleContext(), index, session)
 	}()
 
 	// Define the template for the sealed key object, using the computed policy digest
@@ -340,8 +354,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 	// Have the digest of the private data recorded in the creation data for the sealed data object.
 	var privateData privateKeyData
 	privateData.Data.AuthorizeKeyPrivate = x509.MarshalPKCS1PrivateKey(authKey)
-	privateData.Data.PolicyRevokeIndexHandle = policyRevokeIndex.Handle()
-	privateData.Data.PolicyRevokeIndexName = policyRevokeIndex.Name()
+	privateData.Data.PolicyRevokeIndexPublic = policyRevokeIndexPub
 
 	h := crypto.SHA256.New()
 	if err := tpm2.MarshalToWriter(h, &privateData.Data); err != nil {
@@ -352,7 +365,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 	// at has a different name (ie, if we're connected via a resource manager and somebody swapped the object with another one), this
 	// command will fail. We take advantage of parameter encryption here too.
 	priv, pub, creationData, _, creationTicket, err :=
-		tpm.Create(srkContext, &sensitive, &template, h.Sum(nil), nil, nil, session.AddAttrs(tpm2.AttrCommandEncrypt))
+		tpm.Create(srkContext, &sensitive, &template, h.Sum(nil), nil, session.IncludeAttrs(tpm2.AttrCommandEncrypt))
 	if err != nil {
 		return xerrors.Errorf("cannot create sealed data object for key: %w", err)
 	}
@@ -362,8 +375,7 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 
 	// Create a dynamic authorization policy
 	dynamicPolicyData, err :=
-		computeKeyDynamicAuthPolicy(tpm.TPMContext, sealedKeyNameAlg, staticPolicyData.AuthorizeKeyPublic.NameAlg, &privateData, policy,
-			session)
+		computeKeyDynamicAuthPolicy(tpm.TPMContext, sealedKeyNameAlg, staticPolicyData.AuthorizeKeyPublic.NameAlg, &privateData, policy, session)
 	if err != nil {
 		return err
 	}
@@ -388,6 +400,10 @@ func SealKeyToTPM(tpm *TPMConnection, keyDest, privateDest string, create *Creat
 		}
 	}
 
+	policyRevokeIndex, err := tpm2.CreateNVIndexResourceContextFromPublic(policyRevokeIndexPub)
+	if err != nil {
+		return xerrors.Errorf("cannot increment dynamic policy revocation NV counter: cannot create context for NV index: %w", err)
+	}
 	if err := incrementPolicyRevocationNvIndex(tpm.TPMContext, policyRevokeIndex, authKey, data.StaticPolicyData.AuthorizeKeyPublic,
 		session); err != nil {
 		return xerrors.Errorf("cannot increment dynamic policy revocation NV counter: %w", err)
@@ -432,7 +448,7 @@ func UpdateKeyAuthPolicy(tpm *TPMConnection, keyPath, privatePath string, params
 		return InvalidKeyFileError{err.Error()}
 	}
 
-	if err := data.validate(tpm.TPMContext, privateData, session); err != nil {
+	if err := data.validate(tpm, privateData); err != nil {
 		switch e := err.(type) {
 		case keyFileError:
 			return InvalidKeyFileError{"integrity check failed: " + e.err.Error()}
@@ -455,8 +471,14 @@ func UpdateKeyAuthPolicy(tpm *TPMConnection, keyPath, privatePath string, params
 		return xerrors.Errorf("cannot write key data file: %v", err)
 	}
 
-	policyRevokeIndex, _ := tpm.WrapHandle(privateData.Data.PolicyRevokeIndexHandle)
-	authKey, _ := x509.ParsePKCS1PrivateKey(privateData.Data.AuthorizeKeyPrivate)
+	policyRevokeIndex, err := tpm2.CreateNVIndexResourceContextFromPublic(privateData.Data.PolicyRevokeIndexPublic)
+	if err != nil {
+		return xerrors.Errorf("cannot revoke old authorization policies: cannot create context for policy revocation NV index: %w", err)
+	}
+	authKey, err := x509.ParsePKCS1PrivateKey(privateData.Data.AuthorizeKeyPrivate)
+	if err != nil {
+		return xerrors.Errorf("cannot revoke old authorization policies: cannot parse authorization key: %w", err)
+	}
 	if err := incrementPolicyRevocationNvIndex(tpm.TPMContext, policyRevokeIndex, authKey, data.StaticPolicyData.AuthorizeKeyPublic,
 		session); err != nil {
 		return xerrors.Errorf("cannot revoke old authorization policies: %w", err)
@@ -474,13 +496,8 @@ func UpdateKeyAuthPolicy(tpm *TPMConnection, keyPath, privatePath string, params
 // AuthFailError error will be returned and the key data file won't be deleted.
 //
 // This function requires the TPM to be correctly provisioned, else a ErrProvisioningError error will be returned.
-func DeleteKey(tpm *TPMConnection, path string, ownerAuth []byte) error {
+func DeleteKey(tpm *TPMConnection, path string) error {
 	session := tpm.HmacSession()
-	if ok, err := hasValidSRK(tpm.TPMContext, session); err != nil {
-		return err
-	} else if !ok {
-		return ErrProvisioning
-	}
 
 	f, err := os.Open(path)
 	if err != nil {
@@ -492,18 +509,22 @@ func DeleteKey(tpm *TPMConnection, path string, ownerAuth []byte) error {
 		return InvalidKeyFileError{err.Error()}
 	}
 
-	keyContext, err := data.load(tpm.TPMContext, session)
+	keyContext, err := data.load(tpm)
 	if err != nil {
-		switch e := err.(type) {
-		case keyFileError:
-			return InvalidKeyFileError{e.err.Error()}
+		var kfErr keyFileError
+		var ruErr tpm2.ResourceUnavailableError
+		switch {
+		case xerrors.As(err, &kfErr):
+			return InvalidKeyFileError{kfErr.err.Error()}
+		case xerrors.As(err, &ruErr):
+			return ErrProvisioning
 		}
 		return xerrors.Errorf("cannot load existing key data file: %w", err)
 	}
 	tpm.FlushContext(keyContext)
 
-	if policyRevokeContext, err := tpm.WrapHandle(data.DynamicPolicyData.PolicyRevokeIndexHandle); err == nil {
-		if err := tpm.NVUndefineSpace(tpm2.HandleOwner, policyRevokeContext, session.WithAuthValue(ownerAuth)); err != nil {
+	if policyRevokeContext, err := tpm.CreateResourceContextFromTPM(data.DynamicPolicyData.PolicyRevokeIndexHandle); err == nil {
+		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), policyRevokeContext, session); err != nil {
 			if isAuthFailError(err) {
 				return AuthFailError{tpm2.HandleOwner}
 			}
@@ -511,8 +532,8 @@ func DeleteKey(tpm *TPMConnection, path string, ownerAuth []byte) error {
 		}
 	}
 
-	if pinContext, err := tpm.WrapHandle(data.StaticPolicyData.PinIndexHandle); err == nil {
-		if err := tpm.NVUndefineSpace(tpm2.HandleOwner, pinContext, session.WithAuthValue(ownerAuth)); err != nil {
+	if pinContext, err := tpm.CreateResourceContextFromTPM(data.StaticPolicyData.PinIndexHandle); err == nil {
+		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), pinContext, session); err != nil {
 			if isAuthFailError(err) {
 				return AuthFailError{tpm2.HandleOwner}
 			}

--- a/secureboot_policy_test.go
+++ b/secureboot_policy_test.go
@@ -395,7 +395,7 @@ func replayLogToTPM(t *testing.T, tpm *TPMConnection, tcti *tpm2.TctiMssim, logP
 		for alg, digest := range event.Digests {
 			digests = append(digests, tpm2.TaggedHash{HashAlg: tpm2.HashAlgorithmId(alg), Digest: tpm2.Digest(digest)})
 		}
-		if err := tpm.PCRExtend(tpm2.Handle(event.PCRIndex), digests, nil); err != nil {
+		if err := tpm.PCRExtend(tpm.PCRHandleContext(int(event.PCRIndex)), digests, nil); err != nil {
 			t.Fatalf("PCRExtend failed: %v", err)
 		}
 	}

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -60,12 +60,12 @@ var (
 )
 
 func deleteKey(t *testing.T, tpm *TPMConnection, path string) {
-	if err := DeleteKey(tpm, path, nil); err != nil {
+	if err := DeleteKey(tpm, path); err != nil {
 		t.Errorf("DeleteKey failed: %v", err)
 	}
 }
 
-func flushContext(t *testing.T, tpm *TPMConnection, context tpm2.ResourceContext) {
+func flushContext(t *testing.T, tpm *TPMConnection, context tpm2.HandleContext) {
 	if err := tpm.FlushContext(context); err != nil {
 		t.Errorf("FlushContext failed: %v", err)
 	}
@@ -123,10 +123,10 @@ func openTPMForTesting(t *testing.T) *TPMConnection {
 
 // clearTPM clears the TPM with platform hierarchy authorization - something that we can only do on the simulator
 func clearTPMWithPlatformAuth(t *testing.T, tpm *TPMConnection) {
-	if err := tpm.ClearControl(tpm2.HandlePlatform, false, nil); err != nil {
+	if err := tpm.ClearControl(tpm.PlatformHandleContext(), false, nil); err != nil {
 		t.Fatalf("ClearControl failed: %v", err)
 	}
-	if err := tpm.Clear(tpm2.HandlePlatform, nil); err != nil {
+	if err := tpm.Clear(tpm.PlatformHandleContext(), nil); err != nil {
 		t.Fatalf("Clear failed: %v", err)
 	}
 }
@@ -142,7 +142,7 @@ func resetTPMSimulator(t *testing.T, tpm *TPMConnection, tcti *tpm2.TctiMssim) {
 		t.Fatalf("Startup failed: %v", err)
 	}
 
-	if err := tpm.init(nil); err != nil {
+	if err := tpm.init(); err != nil {
 		t.Fatalf("Failed to reinitialize TPMConnection after reset: %v", err)
 	}
 }
@@ -194,7 +194,7 @@ func createTestCA() ([]byte, crypto.PrivateKey, error) {
 }
 
 func createTestEkCert(tpm *tpm2.TPMContext, caCert []byte, caKey crypto.PrivateKey) ([]byte, error) {
-	ekContext, pub, _, _, _, _, err := tpm.CreatePrimary(tpm2.HandleEndorsement, nil, &ekTemplate, nil, nil, nil)
+	ekContext, pub, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, &ekTemplate, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create EK: %v", err)
 	}
@@ -277,12 +277,11 @@ func certifyTPM(tpm *tpm2.TPMContext) error {
 			NameAlg: tpm2.HashAlgorithmSHA256,
 			Attrs:   tpm2.MakeNVAttributes(tpm2.AttrNVPPWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVNoDA|tpm2.AttrNVPlatformCreate, tpm2.NVTypeOrdinary),
 			Size:    uint16(len(cert))}
-		if err := tpm.NVDefineSpace(tpm2.HandlePlatform, nil, &nvPub, nil); err != nil {
+		index, err := tpm.NVDefineSpace(tpm.PlatformHandleContext(), nil, &nvPub, nil)
+		if err != nil {
 			return fmt.Errorf("cannot define NV index for EK certificate: %v", err)
 		}
-		platform, _ := tpm.WrapHandle(tpm2.HandlePlatform)
-		index, _ := tpm.WrapHandle(ekCertHandle)
-		if err := tpm.NVWrite(platform, index, tpm2.MaxNVBuffer(cert), 0, nil); err != nil {
+		if err := tpm.NVWrite(tpm.PlatformHandleContext(), index, tpm2.MaxNVBuffer(cert), 0, nil); err != nil {
 			return fmt.Errorf("cannot write EK certificate to NV index: %v", err)
 		}
 	}
@@ -341,11 +340,8 @@ func TestConnectToDefaultTPM(t *testing.T) {
 			}
 		}
 		session := tpm.HmacSession()
-		if session == nil || session.Context == nil || session.Context.Handle().Type() != tpm2.HandleTypeHMACSession {
+		if session == nil || session.Handle().Type() != tpm2.HandleTypeHMACSession {
 			t.Fatalf("TPMConnection.HmacSession returned invalid session context")
-		}
-		if session.Attrs != tpm2.AttrContinueSession {
-			t.Errorf("TPMConnection.HmacSession returned invalid attributes")
 		}
 	}
 
@@ -363,7 +359,7 @@ func TestConnectToDefaultTPM(t *testing.T) {
 			tpm := connectAndClear(t)
 			defer closeTPM(t, tpm)
 
-			if err := ProvisionTPM(tpm, ProvisionModeFull, nil, nil); err != nil {
+			if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 				t.Fatalf("ProvisionTPM failed: %v", err)
 			}
 		}()
@@ -376,40 +372,39 @@ func TestConnectToDefaultTPM(t *testing.T) {
 			tpm := connectAndClear(t)
 			defer closeTPM(t, tpm)
 
-			primary, _, _, _, _, _, err := tpm.CreatePrimary(tpm2.HandleEndorsement, nil, &ekTemplate, nil, nil, nil)
+			primary, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), nil, &ekTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}
 			defer flushContext(t, tpm, primary)
 
-			sessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256, nil)
+			sessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)
 			if err != nil {
 				t.Fatalf("StartAuthSession failed: %v", err)
 			}
 			defer flushContext(t, tpm, sessionContext)
+			sessionContext.SetAttrs(tpm2.AttrContinueSession)
 
-			endorsement, _ := tpm.WrapHandle(tpm2.HandleEndorsement)
-			if _, _, err := tpm.PolicySecret(endorsement, sessionContext, nil, nil, 0, nil); err != nil {
+			if _, _, err := tpm.PolicySecret(tpm.EndorsementHandleContext(), sessionContext, nil, nil, 0, nil); err != nil {
 				t.Fatalf("PolicySecret failed: %v", err)
 			}
 
-			session := tpm2.Session{Context: sessionContext, Attrs: tpm2.AttrContinueSession}
-			priv, pub, _, _, _, err := tpm.Create(primary, nil, &ekTemplate, nil, nil, &session)
+			priv, pub, _, _, _, err := tpm.Create(primary, nil, &ekTemplate, nil, nil, sessionContext)
 			if err != nil {
 				t.Fatalf("Create failed: %v", err)
 			}
 
-			if _, _, err := tpm.PolicySecret(endorsement, sessionContext, nil, nil, 0, nil); err != nil {
+			if _, _, err := tpm.PolicySecret(tpm.EndorsementHandleContext(), sessionContext, nil, nil, 0, nil); err != nil {
 				t.Fatalf("PolicySecret failed: %v", err)
 			}
 
-			context, _, err := tpm.Load(primary, priv, pub, &session)
+			context, err := tpm.Load(primary, priv, pub, sessionContext)
 			if err != nil {
 				t.Fatalf("Load failed: %v", err)
 			}
 			defer flushContext(t, tpm, context)
 
-			if _, err := tpm.EvictControl(tpm2.HandleOwner, context, ekHandle, nil); err != nil {
+			if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), context, ekHandle, nil); err != nil {
 				t.Errorf("EvictControl failed: %v", err)
 			}
 		}()
@@ -422,7 +417,7 @@ func TestConnectToDefaultTPM(t *testing.T) {
 		func() {
 			tpm := connectAndClear(t)
 			defer closeTPM(t, tpm)
-			if err := tpm.HierarchyChangeAuth(tpm2.HandleEndorsement, testAuth, nil); err != nil {
+			if err := tpm.HierarchyChangeAuth(tpm.EndorsementHandleContext(), testAuth, nil); err != nil {
 				t.Fatalf("HierarchyChangeAuth failed: %v", err)
 			}
 		}()
@@ -499,11 +494,8 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 			}
 		}
 		session := tpm.HmacSession()
-		if session == nil || session.Context == nil || session.Context.Handle().Type() != tpm2.HandleTypeHMACSession {
+		if session == nil || session.Handle().Type() != tpm2.HandleTypeHMACSession {
 			t.Fatalf("TPMConnection.HmacSession returned invalid session context")
-		}
-		if session.Attrs != tpm2.AttrContinueSession {
-			t.Errorf("TPMConnection.HmacSession returned invalid attributes")
 		}
 	}
 
@@ -524,7 +516,7 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 			tpm := connectAndClear(t)
 			defer closeTPM(t, tpm)
 
-			if err := tpm.HierarchyChangeAuth(tpm2.HandleEndorsement, testAuth, nil); err != nil {
+			if err := tpm.HierarchyChangeAuth(tpm.EndorsementHandleContext(), testAuth, nil); err != nil {
 				t.Fatalf("HierarchyChangeAuth failed: %v", err)
 			}
 		}()
@@ -540,7 +532,7 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 			tpm := connectAndClear(t)
 			defer closeTPM(t, tpm)
 
-			if err := tpm.HierarchyChangeAuth(tpm2.HandleEndorsement, []byte("1234"), nil); err != nil {
+			if err := tpm.HierarchyChangeAuth(tpm.EndorsementHandleContext(), []byte("1234"), nil); err != nil {
 				t.Fatalf("HierarchyChangeAuth failed: %v", err)
 			}
 		}()
@@ -569,7 +561,7 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 			tpm := connectAndClear(t)
 			defer closeTPM(t, tpm)
 
-			if err := ProvisionTPM(tpm, ProvisionModeFull, nil, nil); err != nil {
+			if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
 				t.Fatalf("ProvisionTPM failed: %v", err)
 			}
 		}()
@@ -665,12 +657,12 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 
 			// This produces a primary key that doesn't match the certificate created in TestMain
 			sensitive := tpm2.SensitiveCreate{Data: []byte("foo")}
-			ekContext, _, _, _, _, _, err := tpm.CreatePrimary(tpm2.HandleEndorsement, &sensitive, &ekTemplate, nil, nil, nil)
+			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, &ekTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}
 			defer tpm.FlushContext(ekContext)
-			if _, err := tpm.EvictControl(tpm2.HandleOwner, ekContext, ekHandle, nil); err != nil {
+			if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), ekContext, ekHandle, nil); err != nil {
 				t.Errorf("EvictControl failed: %v", err)
 			}
 		}()
@@ -688,16 +680,16 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 
 			// This produces a primary key that doesn't match the certificate created in TestMain
 			sensitive := tpm2.SensitiveCreate{Data: []byte("foo")}
-			ekContext, _, _, _, _, _, err := tpm.CreatePrimary(tpm2.HandleEndorsement, &sensitive, &ekTemplate, nil, nil, nil)
+			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, &ekTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}
 			defer tpm.FlushContext(ekContext)
-			if _, err := tpm.EvictControl(tpm2.HandleOwner, ekContext, ekHandle, nil); err != nil {
+			if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), ekContext, ekHandle, nil); err != nil {
 				t.Errorf("EvictControl failed: %v", err)
 			}
 
-			if err := tpm.HierarchyChangeAuth(tpm2.HandleEndorsement, testAuth, nil); err != nil {
+			if err := tpm.HierarchyChangeAuth(tpm.EndorsementHandleContext(), testAuth, nil); err != nil {
 				t.Fatalf("HierarchyChangeAuth failed: %v", err)
 			}
 		}()
@@ -716,16 +708,16 @@ func TestSecureConnectToDefaultTPM(t *testing.T) {
 
 			// This produces a primary key that doesn't match the certificate created in TestMain
 			sensitive := tpm2.SensitiveCreate{Data: []byte("foo")}
-			ekContext, _, _, _, _, _, err := tpm.CreatePrimary(tpm2.HandleEndorsement, &sensitive, &ekTemplate, nil, nil, nil)
+			ekContext, _, _, _, _, err := tpm.CreatePrimary(tpm.EndorsementHandleContext(), &sensitive, &ekTemplate, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("CreatePrimary failed: %v", err)
 			}
 			defer tpm.FlushContext(ekContext)
-			if _, err := tpm.EvictControl(tpm2.HandleOwner, ekContext, ekHandle, nil); err != nil {
+			if _, err := tpm.EvictControl(tpm.OwnerHandleContext(), ekContext, ekHandle, nil); err != nil {
 				t.Errorf("EvictControl failed: %v", err)
 			}
 
-			if err := tpm.HierarchyChangeAuth(tpm2.HandleEndorsement, testAuth, nil); err != nil {
+			if err := tpm.HierarchyChangeAuth(tpm.EndorsementHandleContext(), testAuth, nil); err != nil {
 				t.Fatalf("HierarchyChangeAuth failed: %v", err)
 			}
 		}()

--- a/ubuntu-core-cryptsetup/main.go
+++ b/ubuntu-core-cryptsetup/main.go
@@ -263,7 +263,7 @@ func activateWithTPM(volume, sourceDevice, keyFilePath, ekCertFilePath, pinFileP
 				if !reprovisionAttempted {
 					reprovisionAttempted = true
 					fmt.Fprintf(os.Stderr, "TPM is not provisioned correctly - attempting automatic recovery...\n")
-					if err := fdeutil.ProvisionTPM(tpm, fdeutil.ProvisionModeWithoutLockout, nil, nil); err == nil {
+					if err := fdeutil.ProvisionTPM(tpm, fdeutil.ProvisionModeWithoutLockout, nil); err == nil {
 						fmt.Fprintf(os.Stderr, " ...automatic recovery succeeded. Retrying key unseal operation now\n")
 						goto RetryUnseal
 					} else {

--- a/unseal.go
+++ b/unseal.go
@@ -42,20 +42,30 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 	hmacSession := tpm.HmacSession()
 
 	// Load the key data
-	keyContext, err := k.data.load(tpm.TPMContext, hmacSession)
+	keyContext, err := k.data.load(tpm)
 	if err != nil {
 		var kfErr keyFileError
-		if xerrors.As(err, &kfErr) {
-			// A keyFileError can be as a result of an improperly provisioned TPM - detect if
-			// the object at srkHandle is a valid primary key with the correct template. If it's
-			// not, then return a provisioning error.
-			if ok, err := hasValidSRK(tpm.TPMContext, hmacSession); err == nil && !ok {
+		var ruErr tpm2.ResourceUnavailableError
+		switch {
+		case xerrors.As(err, &kfErr):
+			// A keyFileError can be as a result of an improperly provisioned TPM - detect if the object at srkHandle is a valid primary
+			// key with the correct attributes. If it's not, then it's definitely a provisioning error. If it is, then it could still
+			// be a provisioning error because we don't know if the object was created with the same template that ProvisionTPM uses.
+			// In that case, we'll just assume an invalid key file
+			if srkContext, err := tpm.CreateResourceContextFromTPM(srkHandle); err != nil {
+				if _, unavail := err.(tpm2.ResourceUnavailableError); unavail {
+					return nil, ErrProvisioning
+				}
+				return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
+			} else if ok, err := isObjectPrimaryKeyWithTemplate(tpm.TPMContext, tpm.OwnerHandleContext(), srkContext, &srkTemplate, tpm.HmacSession()); err != nil {
+				return nil, xerrors.Errorf("cannot determine if object at SRK handle is a primary key in the storage hierarchy: %w", err)
+			} else if !ok {
 				return nil, ErrProvisioning
 			}
+			// This is probably a broken key file, but it could still be a provisioning error because we don't know if the SRK object was
+			// created with the same template that ProvisionTPM uses.
 			return nil, InvalidKeyFileError{kfErr.err.Error()}
-		}
-		var ruErr tpm2.ResourceUnavailableError
-		if xerrors.As(err, &ruErr) {
+		case xerrors.As(err, &ruErr):
 			return nil, ErrProvisioning
 		}
 		return nil, xerrors.Errorf("cannot load key data file: %w", err)
@@ -63,13 +73,13 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 	defer tpm.FlushContext(keyContext)
 
 	// Begin and execute policy session
-	sessionContext, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, k.data.KeyPublic.NameAlg, nil)
+	policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, k.data.KeyPublic.NameAlg)
 	if err != nil {
 		return nil, xerrors.Errorf("cannot start policy session: %w", err)
 	}
-	defer tpm.FlushContext(sessionContext)
+	defer tpm.FlushContext(policySession)
 
-	if err := executePolicySession(tpm, sessionContext, k.data.StaticPolicyData, k.data.DynamicPolicyData, pin); err != nil {
+	if err := executePolicySession(tpm, policySession, k.data.StaticPolicyData, k.data.DynamicPolicyData, pin); err != nil {
 		var tpmsErr *tpm2.TPMSessionError
 		if xerrors.As(err, &tpmsErr) && tpmsErr.Code() == tpm2.ErrorAuthFail && tpmsErr.Command() == tpm2.CommandPolicySecret {
 			return nil, ErrPinFail
@@ -78,7 +88,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 	}
 
 	// Unseal
-	key, err := tpm.Unseal(keyContext, &tpm2.Session{Context: sessionContext}, hmacSession.AddAttrs(tpm2.AttrResponseEncrypt))
+	key, err := tpm.Unseal(keyContext, policySession, hmacSession.IncludeAttrs(tpm2.AttrResponseEncrypt))
 	if err != nil {
 		if e, ok := err.(*tpm2.TPMSessionError); ok && e.Code() == tpm2.ErrorPolicyFail {
 			return nil, InvalidKeyFileError{"the authorization policy check failed during unsealing"}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "VqAvxeJE9hORJ6vYCC1dFGboZlw=",
+			"checksumSHA1": "RZhBY9v1b7iwtI8PgebpR4wDvCg=",
 			"path": "github.com/chrisccoulson/go-tpm2",
-			"revision": "698c7fec6160afc27f9839fa4984429bbe1ebbcf",
-			"revisionTime": "2019-12-02T18:42:20Z"
+			"revision": "8df9e603c782b36d4ab7fb465828ec82196f76b7",
+			"revisionTime": "2020-02-05T01:36:17Z"
 		},
 		{
 			"checksumSHA1": "emUttBmQY/296swpuBVtuCZ5Ft8=",


### PR DESCRIPTION
This updates to the latest go-tpm2 - a couple of significant changes in this version:

- TPMContext no longer keeps track of ResourceContext instances for TPM resources.
- Authorization values for TPM resources are provided via ResourceContext rather than session parameters.