### PR TITLE
Add support for using a global NV index for locking authorization policies

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -27,6 +27,8 @@ const (
 	srkHandle tpm2.Handle = 0x81000001
 	ekHandle  tpm2.Handle = 0x81010001
 
+	lockHandle tpm2.Handle = 0x01801100
+
 	// SHA-256 is mandatory to exist on every PC-Client TPM
 	// FIXME: Dynamically select algorithms based on what's available on the device
 	defaultSessionHashAlgorithm tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256

--- a/constants.go
+++ b/constants.go
@@ -27,7 +27,7 @@ const (
 	srkHandle tpm2.Handle = 0x81000001
 	ekHandle  tpm2.Handle = 0x81010001
 
-	lockHandle tpm2.Handle = 0x01801100
+	lockNVHandle tpm2.Handle = 0x01801100
 
 	// SHA-256 is mandatory to exist on every PC-Client TPM
 	// FIXME: Dynamically select algorithms based on what's available on the device

--- a/examples/provision-status/provision-status.go
+++ b/examples/provision-status/provision-status.go
@@ -46,6 +46,12 @@ func run() int {
 		fmt.Println("** ERROR: TPM does not have a valid SRK **")
 	}
 
+	if status&fdeutil.AttrValidEK > 0 {
+		fmt.Println("Valid EK found in TPM")
+	} else {
+		fmt.Println("** ERROR: TPM does not have a valid EK **")
+	}
+
 	if status&fdeutil.AttrDAParamsOK > 0 {
 		fmt.Println("TPM's DA parameters are correct")
 	} else {
@@ -62,6 +68,12 @@ func run() int {
 		fmt.Println("The lockout hierarchy authorization is set")
 	} else {
 		fmt.Println("** ERROR: The lockout hierarchy authorization is not set **")
+	}
+
+	if status&fdeutil.AttrLockNVIndex > 0 {
+		fmt.Println("Valid lock NV index found in TPM")
+	} else {
+		fmt.Println("** ERROR: TPM does not have a valid lock NV index **")
 	}
 
 	return 0

--- a/keydata.go
+++ b/keydata.go
@@ -233,7 +233,7 @@ func (d *keyData) validate(tpm *TPMConnection, privateData *privateKeyData) erro
 	if err != nil {
 		return xerrors.Errorf("cannot create context for lock NV index: %v", err)
 	}
-	lockIndexPub, err := getLockNVIndexPublic(tpm.TPMContext, lockIndex, session)
+	lockIndexPub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session)
 	if err != nil {
 		return xerrors.Errorf("cannot determine if NV index at 0x%08x is global lock index: %w", lockNVHandle, err)
 	}

--- a/pin.go
+++ b/pin.go
@@ -43,14 +43,13 @@ func pinNvIndexAuthPolicies(alg tpm2.HashAlgorithmId, keyName tpm2.Name) tpm2.Di
 }
 
 func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, hmacSession tpm2.SessionContext) (*tpm2.NVPublic, tpm2.Name, error) {
-	// To prevent someone with knowledge of the owner authorization (which is empty unless someone has taken
-	// ownership of the TPM) from resetting the PIN by just undefining and redifining a new NV index with the
-	// same properties, require the NV index to be written to and only allow writes with a signed
-	// authorization policy. This works because the name of the signing key is included in the authorization
-	// policy digest for the NV index, and the authorization policy digest and written attribute is included
-	// in the name of the NV index. The name of the NV index is included in the authorization policy for the
-	// sealed key object. Without the private part of the signing key, it is impossible to create a new NV
-	// index with the same name.
+	// To prevent someone with knowledge of the owner authorization (which is empty unless someone has taken ownership of the TPM) from
+	// resetting the PIN by just undefining and redifining a new NV index with the same properties, we need a way to prevent someone
+	// from being able to create an index with the same name. To do this, we require the NV index to be written to and only allow writes
+	// with a signed authorization policy. This works because the name of the signing key is included in the authorization policy digest
+	// for the NV index, and the authorization policy digest and written attribute is included in the name of the NV index. Without the
+	// private part of the signing key, it is impossible to create a new NV index with the same name, and so, if this NV index is
+	// undefined then it becomes impossible to satisfy the authorization policy for the sealed key object.
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/pin.go
+++ b/pin.go
@@ -76,7 +76,7 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, hmacSession tpm2
 	nvPublic := &tpm2.NVPublic{
 		Index:      handle,
 		NameAlg:    nameAlg,
-		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead, tpm2.NVTypeOrdinary),
+		Attrs:      tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead),
 		AuthPolicy: trial.GetDigest(),
 		Size:       0}
 

--- a/pin.go
+++ b/pin.go
@@ -46,10 +46,11 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, hmacSession tpm2
 	// To prevent someone with knowledge of the owner authorization (which is empty unless someone has taken ownership of the TPM) from
 	// resetting the PIN by just undefining and redifining a new NV index with the same properties, we need a way to prevent someone
 	// from being able to create an index with the same name. To do this, we require the NV index to be written to and only allow writes
-	// with a signed authorization policy. This works because the name of the signing key is included in the authorization policy digest
-	// for the NV index, and the authorization policy digest and written attribute is included in the name of the NV index. Without the
-	// private part of the signing key, it is impossible to create a new NV index with the same name, and so, if this NV index is
-	// undefined then it becomes impossible to satisfy the authorization policy for the sealed key object.
+	// with a signed authorization policy. Once initialized, the signing key is discarded. This works because the name of the signing key
+	// is included in the authorization policy digest for the NV index, and the authorization policy digest and written attribute is
+	// included in the name of the NV index. Without the private part of the signing key, it is impossible to create a new NV index with
+	// the same name, and so, if this NV index is undefined then it becomes impossible to satisfy the authorization policy for the sealed
+	// key object.
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -75,7 +76,7 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, hmacSession tpm2
 	nvPublic := &tpm2.NVPublic{
 		Index:      handle,
 		NameAlg:    nameAlg,
-		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVReadStClear, tpm2.NVTypeOrdinary),
+		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead, tpm2.NVTypeOrdinary),
 		AuthPolicy: trial.GetDigest(),
 		Size:       0}
 
@@ -146,8 +147,8 @@ func createPinNvIndex(tpm *tpm2.TPMContext, handle tpm2.Handle, hmacSession tpm2
 		return nil, nil, xerrors.Errorf("cannot initialize NV index: %w", err)
 	}
 
-	// The index has a different name now that it has been written, so update the public area we return so that it can
-	// be used to construct a ResourceContext that will work for it.
+	// The index has a different name now that it has been written, so update the public area we return so that it can be used
+	// to construct an authorization policy.
 	nvPublic.Attrs |= tpm2.AttrNVWritten
 
 	succeeded = true

--- a/policy.go
+++ b/policy.go
@@ -186,8 +186,8 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 	// We use a globally defined NV index created at provisioning time for locking the authorization policy of any sealed key objects we
 	// create, which works by enabling the read lock bit. As this changes the name of the index until the next TPM reset or restart, it
 	// makes any authorization policy that depends on it un-satisfiable. We do this rather than extending an extra value to a PCR, as it
-	// decouples the PCR policy from the locking feature and allows for the option of having more flexible and owner-customizable PCR
-	// policies in the future.
+	// decouples the PCR policy from the locking feature and allows for the option of having more flexible, owner-customizable and maybe
+	// device-specific PCR policies in the future.
 	//
 	// To prevent someone with knowledge of the owner authorization (which is empty unless someone has taken ownership of the TPM) from
 	// clearing the read lock bit by just undefining and redifining a new NV index with the same properties, we need a way to prevent
@@ -195,7 +195,7 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 	// that they can only increment and are initialized with a value larger than the largest count value seen on the TPM. Whilst it
 	// would be possible to recreate a counter with the same name, it wouldn't be possible to recreate one with the same value. Keys
 	// sealed by this package can then execute an assertion that the counter is equal to a certain value. One problem with this is that
-	// the current value needs to be known at key sealing time (as it forms part of the authorization value), and the read lock bit will
+	// the current value needs to be known at key sealing time (as it forms part of the authorization policy), and the read lock bit will
 	// prevent the count value from being read from the TPM. Also, the number of counters available is extremely limited, and we already
 	// use one per sealed key.
 	//

--- a/policy.go
+++ b/policy.go
@@ -266,6 +266,9 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 		Size:       0}
 	index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, public, session)
 	if err != nil {
+		if isNVIndexDefinedError(err) {
+			return &nvIndexDefinedError{public.Index}
+		}
 		return xerrors.Errorf("cannot create NV index: %w", err)
 	}
 
@@ -342,6 +345,9 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 		Size:    uint16(len(data))}
 	dataIndex, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &dataPublic, session)
 	if err != nil {
+		if isNVIndexDefinedError(err) {
+			return &nvIndexDefinedError{dataPublic.Index}
+		}
 		return xerrors.Errorf("cannot create data NV index: %w", err)
 	}
 

--- a/policy.go
+++ b/policy.go
@@ -212,7 +212,7 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 	// to use those to determine whether the lock NV index has a valid authorization policy.
 
 	if existing, err := tpm.CreateResourceContextFromTPM(lockNVHandle); err == nil {
-		if pub, _ := getLockNVIndexPublic(tpm, existing, session); pub != nil {
+		if pub, _ := readAndValidateLockNVIndexPublic(tpm, existing, session); pub != nil {
 			return nil
 		}
 	}
@@ -354,7 +354,7 @@ func ensureLockNVIndex(tpm *tpm2.TPMContext, session tpm2.SessionContext) error 
 	return nil
 }
 
-func getLockNVIndexPublic(tpm *tpm2.TPMContext, index tpm2.ResourceContext, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
+func readAndValidateLockNVIndexPublic(tpm *tpm2.TPMContext, index tpm2.ResourceContext, session tpm2.SessionContext) (*tpm2.NVPublic, error) {
 	// Obtain the data recorded alongside the lock NV index for validating that the lock NV index has a valid
 	// authorization policy.
 	dataIndex, err := tpm.CreateResourceContextFromTPM(lockNVDataHandle)

--- a/policy_test.go
+++ b/policy_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	_ "crypto/sha256"
+	"encoding/binary"
 	"math/big"
 	"testing"
 
@@ -32,6 +33,295 @@ import (
 
 	"golang.org/x/xerrors"
 )
+
+func TestEnsureLockNVIndex(t *testing.T) {
+	tpm, _ := openTPMSimulatorForTesting(t)
+	defer closeTPM(t, tpm)
+
+	clearTPMWithPlatformAuth(t, tpm)
+
+	if err := ensureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+		t.Errorf("ensureLockNVIndex failed: %v", err)
+	}
+
+	index, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
+	if err != nil {
+		t.Fatalf("No lock NV index created")
+	}
+	origName := index.Name()
+
+	public, _, err := tpm.NVReadPublic(index)
+	if err != nil {
+		t.Fatalf("NVReadPublic failed: %v", err)
+	}
+
+	if public.Attrs != lockNVIndexAttrs|tpm2.AttrNVWritten {
+		t.Errorf("incorrect lock NV index attributes")
+	}
+
+	if err := ensureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+		t.Errorf("ensureLockNVIndex failed: %v", err)
+	}
+
+	index, err = tpm.CreateResourceContextFromTPM(lockNVHandle)
+	if err != nil {
+		t.Fatalf("No lock NV index created")
+	}
+	if !bytes.Equal(index.Name(), origName) {
+		t.Errorf("lock NV index shouldn't have been recreated")
+	}
+}
+
+func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
+	tpm, _ := openTPMSimulatorForTesting(t)
+	defer func() {
+		clearTPMWithPlatformAuth(t, tpm)
+		closeTPM(t, tpm)
+	}()
+
+	prepare := func(t *testing.T) (tpm2.ResourceContext, tpm2.ResourceContext) {
+		clearTPMWithPlatformAuth(t, tpm)
+		if err := ensureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+			t.Errorf("ensureLockNVIndex failed: %v", err)
+		}
+		index, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
+		if err != nil {
+			t.Fatalf("No lock NV index created")
+		}
+		dataIndex, err := tpm.CreateResourceContextFromTPM(lockNVDataHandle)
+		if err != nil {
+			t.Fatalf("No lock NV data index created")
+		}
+		return index, dataIndex
+	}
+
+	t.Run("Good", func(t *testing.T) {
+		index, _ := prepare(t)
+		pub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
+		if err != nil {
+			t.Fatalf("readAndValidateLockNVIndexPublic failed: %v", err)
+		}
+		if pub.Index != lockNVHandle {
+			t.Errorf("Returned public area has wrong handle")
+		}
+		if pub.Attrs != lockNVIndexAttrs|tpm2.AttrNVWritten {
+			t.Errorf("incorrect lock NV index attributes")
+		}
+	})
+
+	t.Run("ReadLocked", func(t *testing.T) {
+		index, _ := prepare(t)
+		if err := tpm.NVReadLock(index, index, nil); err != nil {
+			t.Fatalf("NVReadLock failed: %v", err)
+		}
+		pub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
+		if err != nil {
+			t.Fatalf("readAndValidateLockNVIndexPublic failed: %v", err)
+		}
+		if pub.Index != lockNVHandle {
+			t.Errorf("Returned public area has wrong handle")
+		}
+		if pub.Attrs != lockNVIndexAttrs|tpm2.AttrNVWritten {
+			t.Errorf("incorrect lock NV index attributes")
+		}
+	})
+
+	t.Run("NoPolicyDataIndex", func(t *testing.T) {
+		index, dataIndex := prepare(t)
+		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), dataIndex, nil); err != nil {
+			t.Fatalf("NVUndefineSpace failed: %v", err)
+		}
+		pub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
+		if err == nil {
+			t.Fatalf("readAndValidateLockNVIndexPublic should have failed")
+		}
+		if pub != nil {
+			t.Errorf("readAndValidateLockNVIndexPublic should have returned no public area")
+		}
+		var ruErr tpm2.ResourceUnavailableError
+		if !xerrors.As(err, &ruErr) {
+			t.Errorf("Unexpected error type")
+		}
+		if err.Error() != "cannot obtain context for policy data NV index: a resource at handle 0x01801101 is not available on the TPM" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("IncorrectClockValue", func(t *testing.T) {
+		index, dataIndex := prepare(t)
+
+		// Test with a policy data index that indicates a time in the future.
+
+		dataPub, _, err := tpm.NVReadPublic(dataIndex)
+		if err != nil {
+			t.Fatalf("NVReadPublic failed: %v", err)
+		}
+		data, err := tpm.NVRead(dataIndex, dataIndex, dataPub.Size, 0, nil)
+		if err != nil {
+			t.Fatalf("NVRead failed: %v", err)
+		}
+		var version uint8
+		var keyName tpm2.Name
+		var clockBytes []byte
+		if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clockBytes); err != nil {
+			t.Fatalf("UnmarshalFromBytes failed: %v", err)
+		}
+
+		time, err := tpm.ReadClock()
+		if err != nil {
+			t.Fatalf("ReadClock failed: %v", err)
+		}
+		binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock+3600000)
+
+		data, err = tpm2.MarshalToBytes(version, keyName, clockBytes)
+		if err != nil {
+			t.Errorf("MarshalToBytes failed: %v", err)
+		}
+
+		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), dataIndex, nil); err != nil {
+			t.Fatalf("NVUndefineSpace failed: %v", err)
+		}
+
+		public := tpm2.NVPublic{
+			Index:   lockNVDataHandle,
+			NameAlg: tpm2.HashAlgorithmSHA256,
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
+			Size:    uint16(len(data))}
+		dataIndex, err = tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &public, nil)
+		if err != nil {
+			t.Fatalf("NVDefineSpace failed: %v", err)
+		}
+		if err := tpm.NVWrite(dataIndex, dataIndex, data, 0, nil); err != nil {
+			t.Errorf("NVWrite failed: %v", err)
+		}
+		pub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
+		if err == nil {
+			t.Fatalf("readAndValidateLockNVIndexPublic should have failed")
+		}
+		if pub != nil {
+			t.Errorf("readAndValidateLockNVIndexPublic should have returned no public area")
+		}
+		if err.Error() != "unexpected clock value in policy data" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	t.Run("IncorrectPolicy", func(t *testing.T) {
+		clearTPMWithPlatformAuth(t, tpm)
+
+		// Test with a bogus lock NV index that allows writes far in to the future, making it possible
+		// to recreate it to remove the read lock bit.
+
+		key, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatalf("GenerateKey failed: %v", err)
+		}
+
+		keyPublic := createPublicAreaForRSASigningKey(&key.PublicKey)
+		keyName, err := keyPublic.Name()
+		if err != nil {
+			t.Errorf("Cannot compute key name: %v", err)
+		}
+
+		time, err := tpm.ReadClock()
+		if err != nil {
+			t.Fatalf("ReadClock failed: %v", err)
+		}
+		time.ClockInfo.Clock += 5000
+		clockBytes := make(tpm2.Operand, binary.Size(time.ClockInfo.Clock))
+		binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock+3600000000)
+
+		trial, _ := tpm2.ComputeAuthPolicy(tpm2.HashAlgorithmSHA256)
+		trial.PolicyCommandCode(tpm2.CommandNVWrite)
+		trial.PolicyCounterTimer(clockBytes, 8, tpm2.OpUnsignedLT)
+		trial.PolicySigned(keyName, nil)
+
+		public := tpm2.NVPublic{
+			Index:      lockNVHandle,
+			NameAlg:    tpm2.HashAlgorithmSHA256,
+			Attrs:      lockNVIndexAttrs,
+			AuthPolicy: trial.GetDigest(),
+			Size:       0}
+		index, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &public, nil)
+		if err != nil {
+			t.Fatalf("NVDefineSpace failed: %v", err)
+		}
+
+		policySession, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypePolicy, nil, tpm2.HashAlgorithmSHA256)
+		if err != nil {
+			t.Fatalf("StartAuthSession failed: %v", err)
+		}
+		defer tpm.FlushContext(policySession)
+
+		h := tpm2.HashAlgorithmSHA256.NewHash()
+		h.Write(policySession.NonceTPM())
+		binary.Write(h, binary.BigEndian, int32(0))
+
+		sig, err := rsa.SignPSS(rand.Reader, key, tpm2.HashAlgorithmSHA256.GetHash(), h.Sum(nil), &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+		if err != nil {
+			t.Errorf("SignPSS failed: %v", err)
+		}
+
+		keyLoaded, err := tpm.LoadExternal(nil, keyPublic, tpm2.HandleEndorsement)
+		if err != nil {
+			t.Fatalf("LoadExternal failed: %v", err)
+		}
+		defer tpm.FlushContext(keyLoaded)
+
+		signature := tpm2.Signature{
+			SigAlg: tpm2.SigSchemeAlgRSAPSS,
+			Signature: tpm2.SignatureU{
+				Data: &tpm2.SignatureRSAPSS{
+					Hash: tpm2.HashAlgorithmSHA256,
+					Sig:  tpm2.PublicKeyRSA(sig)}}}
+
+		if err := tpm.PolicyCommandCode(policySession, tpm2.CommandNVWrite); err != nil {
+			t.Errorf("Assertion failed: %v", err)
+		}
+		if err := tpm.PolicyCounterTimer(policySession, clockBytes, 8, tpm2.OpUnsignedLT); err != nil {
+			t.Errorf("Assertion failed: %v", err)
+		}
+		if _, _, err := tpm.PolicySigned(keyLoaded, policySession, true, nil, nil, 0, &signature); err != nil {
+			t.Errorf("Assertion failed: %v", err)
+		}
+
+		if err := tpm.NVWrite(index, index, nil, 0, policySession); err != nil {
+			t.Errorf("NVWrite failed: %v", err)
+		}
+
+		binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock)
+		data, err := tpm2.MarshalToBytes(uint8(0), keyName, clockBytes)
+		if err != nil {
+			t.Fatalf("MarshalToBytes failed: %v", err)
+		}
+
+		// Create the data index.
+		dataPublic := tpm2.NVPublic{
+			Index:   lockNVDataHandle,
+			NameAlg: tpm2.HashAlgorithmSHA256,
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVAuthWrite | tpm2.AttrNVWriteDefine | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA),
+			Size:    uint16(len(data))}
+		dataIndex, err := tpm.NVDefineSpace(tpm.OwnerHandleContext(), nil, &dataPublic, nil)
+		if err != nil {
+			t.Fatalf("NVDefineSpace failed: %v", err)
+		}
+
+		if err := tpm.NVWrite(dataIndex, dataIndex, data, 0, nil); err != nil {
+			t.Errorf("NVWrite failed: %v", err)
+		}
+
+		pub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, index, tpm.HmacSession())
+		if err == nil {
+			t.Fatalf("readAndValidateLockNVIndexPublic should have failed")
+		}
+		if pub != nil {
+			t.Errorf("readAndValidateLockNVIndexPublic should have returned no public area")
+		}
+		if err.Error() != "incorrect policy for NV index" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+}
 
 type mockResourceContext struct {
 	name   tpm2.Name
@@ -50,7 +340,7 @@ func TestComputeStaticPolicy(t *testing.T) {
 	pinIndexPub := &tpm2.NVPublic{
 		Index:      testCreationParams.PinHandle,
 		NameAlg:    tpm2.HashAlgorithmSHA256,
-		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVReadStClear, tpm2.NVTypeOrdinary),
+		Attrs:      tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVReadStClear),
 		AuthPolicy: make(tpm2.Digest, tpm2.HashAlgorithmSHA256.Size()),
 		Size:       0}
 	pinName, _ := pinIndexPub.Name()
@@ -58,7 +348,7 @@ func TestComputeStaticPolicy(t *testing.T) {
 	lockIndexPub := tpm2.NVPublic{
 		Index:      lockNVHandle,
 		NameAlg:    tpm2.HashAlgorithmSHA256,
-		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVNoDA|tpm2.AttrNVReadStClear|tpm2.AttrNVWritten, tpm2.NVTypeOrdinary),
+		Attrs:      tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVReadStClear | tpm2.AttrNVWritten),
 		AuthPolicy: make(tpm2.Digest, tpm2.HashAlgorithmSHA256.Size()),
 		Size:       0}
 	lockName, _ := lockIndexPub.Name()
@@ -137,7 +427,7 @@ func TestComputeDynamicPolicy(t *testing.T) {
 	revokeIndexPub := &tpm2.NVPublic{
 		Index:      testCreationParams.PolicyRevocationHandle,
 		NameAlg:    tpm2.HashAlgorithmSHA256,
-		Attrs:      tpm2.MakeNVAttributes(tpm2.AttrNVPolicyWrite|tpm2.AttrNVAuthRead, tpm2.NVTypeCounter),
+		Attrs:      tpm2.NVTypeCounter.WithAttrs(tpm2.AttrNVPolicyWrite | tpm2.AttrNVAuthRead),
 		AuthPolicy: make(tpm2.Digest, tpm2.HashAlgorithmSHA256.Size()),
 		Size:       8}
 
@@ -282,12 +572,12 @@ func TestComputeDynamicPolicy(t *testing.T) {
 	}
 }
 
-func TestLockAccess(t *testing.T) {
+func TestLockAccessToSealedKeysUntilTPMReset(t *testing.T) {
 	tpm, tcti := openTPMSimulatorForTesting(t)
 	defer closeTPM(t, tpm)
 
-	if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
-		t.Fatalf("Failed to provision TPM for test: %v", err)
+	if err := ensureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+		t.Errorf("ensureLockNVIndex failed: %v", err)
 	}
 
 	lockIndex, err := tpm.CreateResourceContextFromTPM(lockNVHandle)
@@ -446,8 +736,8 @@ func TestExecutePolicy(t *testing.T) {
 	tpm, tcti := openTPMSimulatorForTesting(t)
 	defer closeTPM(t, tpm)
 
-	if err := ProvisionTPM(tpm, ProvisionModeFull, nil); err != nil {
-		t.Fatalf("Failed to provision TPM for test: %v", err)
+	if err := ensureLockNVIndex(tpm.TPMContext, tpm.HmacSession()); err != nil {
+		t.Errorf("ensureLockNVIndex failed: %v", err)
 	}
 
 	session, err := tpm.StartAuthSession(nil, nil, tpm2.SessionTypeHMAC, nil, defaultSessionHashAlgorithm)

--- a/policy_test.go
+++ b/policy_test.go
@@ -162,8 +162,8 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 		}
 		var version uint8
 		var keyName tpm2.Name
-		var clockBytes []byte
-		if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clockBytes); err != nil {
+		var clock uint64
+		if _, err := tpm2.UnmarshalFromBytes(data, &version, &keyName, &clock); err != nil {
 			t.Fatalf("UnmarshalFromBytes failed: %v", err)
 		}
 
@@ -171,9 +171,8 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ReadClock failed: %v", err)
 		}
-		binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock+3600000)
 
-		data, err = tpm2.MarshalToBytes(version, keyName, clockBytes)
+		data, err = tpm2.MarshalToBytes(version, keyName, time.ClockInfo.Clock+3600000)
 		if err != nil {
 			t.Errorf("MarshalToBytes failed: %v", err)
 		}
@@ -289,8 +288,7 @@ func TestReadAndValidateLockNVIndexPublic(t *testing.T) {
 			t.Errorf("NVWrite failed: %v", err)
 		}
 
-		binary.BigEndian.PutUint64(clockBytes, time.ClockInfo.Clock)
-		data, err := tpm2.MarshalToBytes(uint8(0), keyName, clockBytes)
+		data, err := tpm2.MarshalToBytes(uint8(0), keyName, time.ClockInfo.Clock)
 		if err != nil {
 			t.Fatalf("MarshalToBytes failed: %v", err)
 		}

--- a/provisioning.go
+++ b/provisioning.go
@@ -407,9 +407,7 @@ func ProvisionStatus(tpm *TPMConnection) (ProvisionStatusAttributes, error) {
 		if _, unavail := err.(tpm2.ResourceUnavailableError); !unavail {
 			return 0, err
 		}
-	} else if pub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session); err != nil {
-		return 0, xerrors.Errorf("cannot determine if NV index at 0x%08x is global lock index: %w", lockNVHandle, err)
-	} else if pub != nil {
+	} else if _, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session); err == nil {
 		out |= AttrLockNVIndex
 	}
 

--- a/provisioning.go
+++ b/provisioning.go
@@ -407,7 +407,7 @@ func ProvisionStatus(tpm *TPMConnection) (ProvisionStatusAttributes, error) {
 		if _, unavail := err.(tpm2.ResourceUnavailableError); !unavail {
 			return 0, err
 		}
-	} else if pub, err := getLockNVIndexPublic(tpm.TPMContext, lockIndex, session); err != nil {
+	} else if pub, err := readAndValidateLockNVIndexPublic(tpm.TPMContext, lockIndex, session); err != nil {
 		return 0, xerrors.Errorf("cannot determine if NV index at 0x%08x is global lock index: %w", lockNVHandle, err)
 	} else if pub != nil {
 		out |= AttrLockNVIndex

--- a/provisioning.go
+++ b/provisioning.go
@@ -243,9 +243,8 @@ func ProvisionTPM(tpm *TPMConnection, mode ProvisionMode, newLockoutAuth []byte)
 
 	// Provision a lock NV index
 	if err := ensureLockNVIndex(tpm.TPMContext, session); err != nil {
-		if isNVIndexDefinedError(err) {
-			// FIXME: This could be lockNVHandle or lockNVDataHandle
-			return TPMResourceExistsError{lockNVHandle}
+		if isNVIndexDefinedWithHandleError(err) {
+			return TPMResourceExistsError{err.(*nvIndexDefinedError).handle}
 		}
 		return xerrors.Errorf("cannot create lock NV index: %w", err)
 	}

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -153,6 +153,7 @@ func TestProvisionNewTPM(t *testing.T) {
 
 			validateEK(t, tpm)
 			validateSRK(t, tpm)
+			validateLockNVIndex(t, tpm.TPMContext)
 
 			// Validate the DA parameters
 			props, err := tpm.GetCapabilityTPMProperties(tpm2.PropertyMaxAuthFail, 3)
@@ -367,7 +368,7 @@ func TestRecreateEK(t *testing.T) {
 
 			lockoutAuth := []byte("1234")
 
-			if err := ProvisionTPM(tpm, data.mode, lockoutAuth); err != nil {
+			if err := ProvisionTPM(tpm, ProvisionModeFull, lockoutAuth); err != nil {
 				t.Fatalf("ProvisionTPM failed: %v", err)
 			}
 
@@ -440,7 +441,7 @@ func TestRecreateSRK(t *testing.T) {
 
 			lockoutAuth := []byte("1234")
 
-			if err := ProvisionTPM(tpm, ProvisionModeClear, lockoutAuth); err != nil {
+			if err := ProvisionTPM(tpm, ProvisionModeFull, lockoutAuth); err != nil {
 				t.Fatalf("ProvisionTPM failed: %v", err)
 			}
 

--- a/provisioning_test.go
+++ b/provisioning_test.go
@@ -536,7 +536,7 @@ func TestProvisionWithInvalidEkCert(t *testing.T) {
 
 func TestProvisionStatus(t *testing.T) {
 	tpm, _ := openTPMSimulatorForTesting(t)
-	defer func () {
+	defer func() {
 		clearTPMWithPlatformAuth(t, tpm)
 		closeTPM(t, tpm)
 	}()

--- a/seal.go
+++ b/seal.go
@@ -37,20 +37,6 @@ const (
 	pcrAlgorithm tpm2.HashAlgorithmId = tpm2.HashAlgorithmSHA256
 )
 
-func isNVIndexDefinedError(err error) bool {
-	var tpmError *tpm2.TPMError
-	if !xerrors.As(err, &tpmError) {
-		return false
-	}
-	if tpmError.Code != tpm2.ErrorNVDefined {
-		return false
-	}
-	if tpmError.Command != tpm2.CommandNVDefineSpace {
-		return false
-	}
-	return true
-}
-
 type OSComponentImage interface {
 	fmt.Stringer
 	ReadAll() ([]byte, error)

--- a/seal_unseal_test.go
+++ b/seal_unseal_test.go
@@ -459,9 +459,6 @@ func TestUnsealLockout(t *testing.T) {
 }
 
 func TestSealWithProvisioningError(t *testing.T) {
-	tpm := openTPMForTesting(t)
-	defer closeTPM(t, tpm)
-
 	key := make([]byte, 32)
 	rand.Read(key)
 
@@ -705,8 +702,9 @@ func TestLockAccessAfterUnseal(t *testing.T) {
 	if err == nil {
 		t.Fatalf("UnsealFromTPM should have failed")
 	}
-	if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: the authorization policy check failed "+
-		"during unsealing" {
+	if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: encountered an error whilst executing the " +
+		"authorization policy assertions: policy lock check failed: TPM returned an error whilst executing command TPM_CC_PolicyNV: " +
+		"TPM_RC_NV_LOCKED (NV access locked)" {
 		t.Errorf("Unexpected error: %v", err)
 	}
 

--- a/seal_unseal_test.go
+++ b/seal_unseal_test.go
@@ -702,8 +702,8 @@ func TestLockAccessAfterUnseal(t *testing.T) {
 	if err == nil {
 		t.Fatalf("UnsealFromTPM should have failed")
 	}
-	if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: encountered an error whilst executing the " +
-		"authorization policy assertions: policy lock check failed: TPM returned an error whilst executing command TPM_CC_PolicyNV: " +
+	if _, ok := err.(InvalidKeyFileError); !ok || err.Error() != "invalid key data file: encountered an error whilst executing the "+
+		"authorization policy assertions: policy lock check failed: TPM returned an error whilst executing command TPM_CC_PolicyNV: "+
 		"TPM_RC_NV_LOCKED (NV access locked)" {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -275,7 +275,7 @@ func certifyTPM(tpm *tpm2.TPMContext) error {
 		nvPub := tpm2.NVPublic{
 			Index:   ekCertHandle,
 			NameAlg: tpm2.HashAlgorithmSHA256,
-			Attrs:   tpm2.MakeNVAttributes(tpm2.AttrNVPPWrite|tpm2.AttrNVAuthRead|tpm2.AttrNVNoDA|tpm2.AttrNVPlatformCreate, tpm2.NVTypeOrdinary),
+			Attrs:   tpm2.NVTypeOrdinary.WithAttrs(tpm2.AttrNVPPWrite | tpm2.AttrNVAuthRead | tpm2.AttrNVNoDA | tpm2.AttrNVPlatformCreate),
 			Size:    uint16(len(cert))}
 		index, err := tpm.NVDefineSpace(tpm.PlatformHandleContext(), nil, &nvPub, nil)
 		if err != nil {

--- a/unseal.go
+++ b/unseal.go
@@ -58,7 +58,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 				}
 				return nil, xerrors.Errorf("cannot create context for SRK: %w", err)
 			} else if ok, err := isObjectPrimaryKeyWithTemplate(tpm.TPMContext, tpm.OwnerHandleContext(), srkContext, &srkTemplate, tpm.HmacSession()); err != nil {
-				return nil, xerrors.Errorf("cannot determine if object at SRK handle is a primary key in the storage hierarchy: %w", err)
+				return nil, xerrors.Errorf("cannot determine if object at 0x%08x is a primary key in the storage hierarchy: %w", srkHandle, err)
 			} else if !ok {
 				return nil, ErrProvisioning
 			}
@@ -97,7 +97,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 	}
 
 	if lock {
-		if err := lockAccessUntilTPMReset(tpm.TPMContext, k.data.StaticPolicyData); err != nil {
+		if err := lockAccessToSealedKeysUntilTPMReset(tpm.TPMContext, hmacSession); err != nil {
 			return nil, fmt.Errorf("cannot lock sealed key object from further access: %v", err)
 		}
 	}

--- a/utils.go
+++ b/utils.go
@@ -21,6 +21,7 @@ package fdeutil
 
 import (
 	"crypto/rsa"
+	"fmt"
 
 	"github.com/chrisccoulson/go-tpm2"
 
@@ -44,6 +45,19 @@ func isAuthFailError(err error) bool {
 func isLockoutError(err error) bool {
 	var warning *tpm2.TPMWarning
 	return xerrors.As(err, &warning) && warning.Code == tpm2.WarningLockout
+}
+
+type nvIndexDefinedError struct {
+	handle tpm2.Handle
+}
+
+func (e *nvIndexDefinedError) Error() string {
+	return fmt.Sprintf("NV index defined at 0x%08x", e.handle)
+}
+
+func isNVIndexDefinedWithHandleError(err error) bool {
+	var e *nvIndexDefinedError
+	return xerrors.As(err, &e)
 }
 
 func isNVIndexDefinedError(err error) bool {

--- a/utils.go
+++ b/utils.go
@@ -46,6 +46,11 @@ func isLockoutError(err error) bool {
 	return xerrors.As(err, &warning) && warning.Code == tpm2.WarningLockout
 }
 
+func isNVIndexDefinedError(err error) bool {
+	var tpmErr *tpm2.TPMError
+	return xerrors.As(err, &tpmErr) && tpmErr.Code == tpm2.ErrorNVDefined
+}
+
 func createPublicAreaForRSASigningKey(key *rsa.PublicKey) *tpm2.Public {
 	return &tpm2.Public{
 		Type:    tpm2.ObjectTypeRSA,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "g26bUupBeDs6zqb+vqC+s1yhpNM=",
+			"checksumSHA1": "05OPl0Gp5HMGc02OtXjrmIlmaMg=",
 			"path": "github.com/chrisccoulson/go-tpm2",
-			"revision": "df5fe05d926e5ca09073815be18969db6079df86",
-			"revisionTime": "2020-02-07T16:01:24Z"
+			"revision": "d0e3238284aa6f0637de57ecca7dd7187cac652d",
+			"revisionTime": "2020-02-12T10:30:20Z"
 		},
 		{
 			"checksumSHA1": "emUttBmQY/296swpuBVtuCZ5Ft8=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "RZhBY9v1b7iwtI8PgebpR4wDvCg=",
+			"checksumSHA1": "g26bUupBeDs6zqb+vqC+s1yhpNM=",
 			"path": "github.com/chrisccoulson/go-tpm2",
-			"revision": "8df9e603c782b36d4ab7fb465828ec82196f76b7",
-			"revisionTime": "2020-02-05T01:36:17Z"
+			"revision": "df5fe05d926e5ca09073815be18969db6079df86",
+			"revisionTime": "2020-02-07T16:01:24Z"
 		},
 		{
 			"checksumSHA1": "emUttBmQY/296swpuBVtuCZ5Ft8=",


### PR DESCRIPTION
The previous implementation worked by read locking the PIN NV index, which changes its name until the next TPM reset or restart. Once its name has changed, the TPM2_PolicySecret assertion will always fail. The problem with this is that the PIN NV handle is key object specific (it's specified as a parameter to SealKeyToTPM) and needs to be known by early-boot code. Early boot code obtains the handle by looking in the metadata of the sealed key data file. If someone boots an unencrypted Ubuntu Core image from external media on a device that has an encrypted Ubuntu Core system, the early boot code running from the external media still needs to activate the lock even if it isn't unsealing a key, but it won't be able to determine the handle of the PIN NV index for the key object used to protect the internal encrypted writable partition. The consequence of this is that it would be trivial for an opportunist to create a customized Ubuntu Core image without encryption (using our kernel and early boot components), put it on external media, boot from it on a system that has an encrypted Ubuntu Core install and then access the contents of the internal encrypted volume.

The original technical plan suggested extending an extra value to a PCR, but this makes the locking feature dependent on the PCR policy, and would make it difficult to have more flexible, owner-customizable and maybe device-specific PCR policies in the future.

This new method uses a global NV index, created at provisioning time, shared between any object created with SealKeyToTPM and common across all Ubuntu Core devices. Locking is activated by enabling the read lock, as before. To prevent someone with knowledge of the owner authorization (which is empty unless someone has taken ownership of the TPM) from clearing the read lock bit by just undefining and redifining a new NV index with the same properties, we need a way to prevent someone from being able to create an identical index. One option for this would be to use a NV counter, which has the property that they can only increment and are initialized with a value larger than the largest count value ever seen on the TPM. Whilst it would be possible to recreate a counter with the same name, it wouldn't be possible to recreate one with the same value. Keys sealed by this package can then execute an assertion that the counter is equal to a certain value. One problem with this is that the current value needs to be known at key sealing time (as it forms part of the authorization policy), and the read lock bit will prevent the count value from being read from the TPM. Also, the number of counters available is extremely limited, and we already use one per sealed key.

Another approach is to use an ordinary NV index that can't be recreated with the same name. To do this, we require the NV index to be written to and only allow writes with a signed authorization policy. Once initialized, the signing key is discarded. This works because the name of the signing key is included in the authorization policy digest for the NV index, and the authorization policy digest and written attribute is included in the name of the NV index. Without the private part of the signing key, it is impossible to create a new NV index with the same name, and so, if this NV index is undefined then it becomes impossible to satisfy the authorization policy for any sealed key objects we've created already.

The issue here though is that the globally defined NV index is created at provisioning time, and it may be possible to seal a new key to the TPM at any point in the future without provisioning a new global NV index here (eg, after use of the recovery key). In the time between provisioning and sealing a key to the TPM, an adversary may have created a new NV index with a policy that only allows writes with a signed authorization, initialized it, but then retained the private part of the key. This allows them to undefine and redefine a new NV index with the same name in the future in order to remove the read lock bit. To mitigate this, we include another assertion in the authorization policy that only allows writes during a small time window (sufficient to initialize the index after it is created), and disallows writes once the TPM's clock has advanced past that window. As the parameters of this assertion are included in the authorization policy digest, it becomes impossible even for someone with the private part of the key to create and initialize a NV index with the same name once the TPM's clock has advanced past that point, without performing a clear of the TPM.

The signing key name and the time window during which the index can be initialized are recorded in another NV index so that it is possible to use those to determine whether the lock NV index has an authorization policy that can never be satisfied and so the index can not be recreated.