### PR TITLE
Use a single NV index for the PIN and for revoking dynamic authorization policies

### DIFF
--- a/examples/seal-key/seal-key.go
+++ b/examples/seal-key/seal-key.go
@@ -55,7 +55,6 @@ var masterKeyFile string
 var keyFile string
 var privFile string
 var pinIndex string
-var policyRevocationIndex string
 var ownerAuth string
 var kernels pathList
 var grubs pathList
@@ -67,7 +66,6 @@ func init() {
 	flag.StringVar(&keyFile, "key-file", "", "")
 	flag.StringVar(&privFile, "priv-file", "", "")
 	flag.StringVar(&pinIndex, "pin-index", "", "")
-	flag.StringVar(&policyRevocationIndex, "policy-revocation-index", "", "")
 	flag.StringVar(&ownerAuth, "auth", "", "")
 	flag.Var(&kernels, "with-kernel", "")
 	flag.Var(&grubs, "with-grub", "")
@@ -116,10 +114,6 @@ func run() int {
 			fmt.Fprintf(os.Stderr, "Missing -pin-index\n")
 			return 1
 		}
-		if policyRevocationIndex == "" {
-			fmt.Fprintf(os.Stderr, "Missing -policy-revocation-index\n")
-			return 1
-		}
 
 		var in *os.File
 		if masterKeyFile == "-" {
@@ -135,18 +129,11 @@ func run() int {
 		}
 
 		var pinHandle tpm2.Handle
-		var policyRevokeHandle tpm2.Handle
 		if h, err := hex.DecodeString(pinIndex); err != nil {
 			fmt.Fprintf(os.Stderr, "Invalid -pin-index: %v\n", err)
 			return 1
 		} else {
 			pinHandle = tpm2.Handle(binary.BigEndian.Uint32(h))
-		}
-		if h, err := hex.DecodeString(policyRevocationIndex); err != nil {
-			fmt.Fprintf(os.Stderr, "Invalid -policy-revocation-index: %v\n", err)
-			return 1
-		} else {
-			policyRevokeHandle = tpm2.Handle(binary.BigEndian.Uint32(h))
 		}
 
 		key, err := ioutil.ReadAll(in)
@@ -155,7 +142,7 @@ func run() int {
 			return 1
 		}
 
-		createParams := fdeutil.CreationParams{PolicyRevocationHandle: policyRevokeHandle, PinHandle: pinHandle}
+		createParams := fdeutil.CreationParams{PinHandle: pinHandle}
 		tpm.OwnerHandleContext().SetAuthValue([]byte(ownerAuth))
 
 		if err := fdeutil.SealKeyToTPM(tpm, keyFile, privFile, &createParams, policyParams, key); err != nil {

--- a/seal_unseal_test.go
+++ b/seal_unseal_test.go
@@ -568,14 +568,7 @@ func TestUnsealProvisioningError(t *testing.T) {
 		if err != nil {
 			t.Errorf("No PIN NV index: %v", err)
 		}
-		policyRevokeContext, err := tpm.CreateResourceContextFromTPM(testCreationParams.PolicyRevocationHandle)
-		if err != nil {
-			t.Errorf("No policy revocation NV index: %v", err)
-		}
 		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), pinContext, nil); err != nil {
-			t.Errorf("NVUndefineSpace failed: %v", err)
-		}
-		if err := tpm.NVUndefineSpace(tpm.OwnerHandleContext(), policyRevokeContext, nil); err != nil {
 			t.Errorf("NVUndefineSpace failed: %v", err)
 		}
 	}()

--- a/tpm_test.go
+++ b/tpm_test.go
@@ -28,6 +28,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/binary"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
@@ -40,7 +41,7 @@ import (
 	"github.com/chrisccoulson/go-tpm2"
 )
 
-var testCreationParams = CreationParams{PolicyRevocationHandle: 0x0181ffff, PinHandle: 0x0181fff0}
+var testCreationParams = CreationParams{PinHandle: 0x0181fff0}
 
 var (
 	useTpm         = flag.Bool("use-tpm", false, "")
@@ -58,6 +59,11 @@ var (
 
 	testEncodedEkCertChain []byte
 )
+
+func decodeHexString(s string) []byte {
+	b, _ := hex.DecodeString(s)
+	return b
+}
 
 func deleteKey(t *testing.T, tpm *TPMConnection, path string) {
 	if err := DeleteKey(tpm, path); err != nil {

--- a/unseal.go
+++ b/unseal.go
@@ -42,7 +42,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 	hmacSession := tpm.HmacSession()
 
 	// Load the key data
-	keyContext, err := k.data.load(tpm)
+	keyContext, err := k.data.load(tpm.TPMContext, hmacSession)
 	if err != nil {
 		var kfErr keyFileError
 		var ruErr tpm2.ResourceUnavailableError
@@ -79,7 +79,7 @@ func (k *SealedKeyObject) UnsealFromTPM(tpm *TPMConnection, pin string, lock boo
 	}
 	defer tpm.FlushContext(policySession)
 
-	if err := executePolicySession(tpm, policySession, k.data.StaticPolicyData, k.data.DynamicPolicyData, pin); err != nil {
+	if err := executePolicySession(tpm.TPMContext, policySession, k.data.StaticPolicyData, k.data.DynamicPolicyData, pin, hmacSession); err != nil {
 		var tpmsErr *tpm2.TPMSessionError
 		if xerrors.As(err, &tpmsErr) && tpmsErr.Code() == tpm2.ErrorAuthFail && tpmsErr.Command() == tpm2.CommandPolicySecret {
 			return nil, ErrPinFail


### PR DESCRIPTION
As provisioning uses 2 NV indices, reduce the number of NV indices defined during sealing to just 1, now that there is no longer a reason for them to be separate.